### PR TITLE
tool のサブコマンドを色々追加

### DIFF
--- a/src/Git/Cmd.hs
+++ b/src/Git/Cmd.hs
@@ -26,6 +26,9 @@ commit = command1_ "git" [] "commit"
 add :: [Text] -> Sh ()
 add = command1_ "git" [] "add"
 
+branch :: [Text] -> Sh ()
+branch = command1_ "git" [] "branch"
+
 cloneOrFetch :: Text -> Text -> Sh ()
 cloneOrFetch repoUrl repoName = do
   dir <- pwd

--- a/src/Git/Plantation/Cmd.hs
+++ b/src/Git/Plantation/Cmd.hs
@@ -12,6 +12,7 @@ import           RIO
 
 import           Data.Extensible
 import qualified Drone.Client               as Drone
+import           Git.Plantation.Cmd.Member  as X
 import           Git.Plantation.Cmd.Options as X
 import           Git.Plantation.Cmd.Repo    as X
 import           Git.Plantation.Cmd.Run     as X

--- a/src/Git/Plantation/Cmd/Member.hs
+++ b/src/Git/Plantation/Cmd/Member.hs
@@ -1,0 +1,50 @@
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators    #-}
+
+module Git.Plantation.Cmd.Member where
+
+import           RIO
+
+import           Data.Extensible
+import           Git.Plantation.Cmd.Repo              (splitRepoName)
+import           Git.Plantation.Data
+import           Git.Plantation.Env
+import           GitHub.Data.Name                     (mkName)
+import           GitHub.Endpoints.Repos               (Auth (..))
+import qualified GitHub.Endpoints.Repos.Collaborators as GitHub
+
+type InviteMemberCmd = Record
+  '[ "team" >: Text
+   , "repo" >: Maybe Text
+   , "user" >: Maybe Text
+   ]
+
+inviteMember :: InviteMemberCmd -> Team -> Plant ()
+inviteMember args team =
+  forM_ repos $ \repo -> forM_ member $ \user ->
+    tryAnyWithLogError $ inviteUserToRepo user repo
+  where
+    repos  = maybe (team ^. #repos)  (: []) $ flip lookupRepo' team =<< args ^. #repo
+    member = maybe (team ^. #member) (: []) $ flip lookupUser team =<< args ^. #user
+
+inviteUserToRepo :: User -> Repo -> Plant ()
+inviteUserToRepo user target = do
+  token <- asks (view #token)
+  resp <- liftIO $ GitHub.addCollaborator
+    (OAuth token)
+    (mkName Proxy owner)
+    (mkName Proxy repo)
+    (mkName Proxy $ user ^. #github)
+  case resp of
+    Left err -> logDebug (displayShow err) >> throwIO (InviteUserError err user target)
+    Right _  -> logInfo $ display success
+  where
+    (owner, repo) = splitRepoName $ target ^. #github
+    success = mconcat
+      [ "Success: invite "
+      , user ^. #name, "(", user ^. #github, ")"
+      , " to ", target ^. #github, "."
+      ]

--- a/src/Git/Plantation/Cmd/Options.hs
+++ b/src/Git/Plantation/Cmd/Options.hs
@@ -30,6 +30,7 @@ type SubCmdFields =
    , "new_github_repo"  >: NewGitHubRepoCmd
    , "init_github_repo" >: InitGitHubRepoCmd
    , "init_ci"          >: InitCICmd
+   , "reset_repo"       >: ResetRepoCmd
    , "invite_member"    >: InviteMemberCmd
    ]
 
@@ -56,6 +57,11 @@ instance Run ("init_ci" >: InitCICmd) where
   run' _ = runRepoCmd $ \team problem -> do
     info <- Team.lookupRepo problem team `fromJustWithThrow` UndefinedTeamProblem team problem
     initProblemCI info team problem
+
+instance Run ("reset_repo" >: ResetRepoCmd) where
+  run' _ = runRepoCmd $ \team problem -> do
+    info <- Team.lookupRepo problem team `fromJustWithThrow` UndefinedTeamProblem team problem
+    resetRepo info team problem
 
 runRepoCmd :: (Team -> Problem -> Plant ()) -> Record RepoCmdFields -> Plant ()
 runRepoCmd act args = do

--- a/src/Git/Plantation/Data/Team.hs
+++ b/src/Git/Plantation/Data/Team.hs
@@ -44,3 +44,7 @@ lookupRepo problem = lookupRepo' (problem ^. #repo_name)
 lookupRepo' :: Text -> Team -> Maybe Repo
 lookupRepo' repoName team =
   L.find (\repo -> repoName == repo ^. #problem) (team ^. #repos)
+
+lookupUser :: Text -> Team -> Maybe User
+lookupUser github team =
+  L.find (\user -> github == user ^. #github) (team ^. #member)

--- a/src/Git/Plantation/Env.hs
+++ b/src/Git/Plantation/Env.hs
@@ -14,7 +14,7 @@ import qualified Data.Aeson.Text       as Json
 import           Data.Extensible
 import qualified Drone.Client          as Drone
 import           Git.Plantation.Config
-import           Git.Plantation.Data   (Problem, Team)
+import           Git.Plantation.Data   (Problem, Repo, Team, User)
 import qualified GitHub.Auth           as GitHub
 import qualified GitHub.Data           as GitHub
 import qualified RIO.Text.Lazy         as TL
@@ -62,6 +62,7 @@ mkLogMessage' message =
 data GitPlantException
   = UndefinedTeamProblem Team Problem
   | CreateRepoError GitHub.Error Team Problem
+  | InviteUserError GitHub.Error User Repo
   deriving (Typeable)
 
 instance Exception GitPlantException
@@ -76,3 +77,7 @@ instance Show GitPlantException where
       mkLogMessage'
         "can't create repository"
         (#team @= team <: #problem @= problem <: nil)
+    InviteUserError _err user repo ->
+      mkLogMessage'
+        "can't invite user to repository"
+        (#user @= user <: #repo @= repo <: nil)

--- a/src/Git/Plantation/Env.hs
+++ b/src/Git/Plantation/Env.hs
@@ -37,7 +37,7 @@ fromJustWithThrow :: Exception e => Maybe a -> e -> Plant a
 fromJustWithThrow (Just x) _ = pure x
 fromJustWithThrow Nothing  e = throwIO e
 
-tryAnyWithLogError :: Plant () -> Plant ()
+tryAnyWithLogError :: Plant a -> Plant ()
 tryAnyWithLogError act = tryAny act >>= \case
   Left  e -> logError $ display e
   Right _ -> pure ()

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,7 +3,7 @@ packages:
 - .
 extra-deps:
 - extensible-0.5
-- github-0.20
+- github-0.21
 - servant-github-webhook-0.4.1.0
 - github: matsubara0507/drone-haskell
   commit: aa6f5152dd9ea72cb48a32bdc58c91de2bdc21a9

--- a/tool/Main.hs
+++ b/tool/Main.hs
@@ -41,10 +41,11 @@ options = hsequence
 
 subcmdParser :: Parser SubCmd
 subcmdParser = variantFrom
-    $ #new_repo         @= newRepoCmdParser    `withInfo` "Create repository for team."
-   <: #new_github_repo  @= singleRepoCmdParser `withInfo` "Create new repository for team in GitHub"
-   <: #init_github_repo @= singleRepoCmdParser `withInfo` "Init repository for team in GitHub"
-   <: #init_ci          @= singleRepoCmdParser `withInfo` "Init CI repository by team repository"
+    $ #new_repo         @= newRepoCmdParser      `withInfo` "Create repository for team."
+   <: #new_github_repo  @= singleRepoCmdParser   `withInfo` "Create new repository for team in GitHub"
+   <: #init_github_repo @= singleRepoCmdParser   `withInfo` "Init repository for team in GitHub"
+   <: #init_ci          @= singleRepoCmdParser   `withInfo` "Init CI repository by team repository"
+   <: #invite_member    @= inviteMemberCmdParser `withInfo` "Invite Member to Team Repository"
    <: nil
 
 newRepoCmdParser :: Parser NewRepoCmd
@@ -57,6 +58,13 @@ singleRepoCmdParser :: Parser (Record RepoCmdFields)
 singleRepoCmdParser = hsequence
     $ #repo <@=> strOption (long "repo" <> metavar "TEXT" <> help "Sets reopsitory that wont to controll.")
    <: #team <@=> strArgument (metavar "TEXT" <> help "Sets team that wont to controll.")
+   <: nil
+
+inviteMemberCmdParser :: Parser InviteMemberCmd
+inviteMemberCmdParser = hsequence
+    $ #team <@=> strArgument (metavar "TEXT" <> help "Sets team that wont to controll.")
+   <: #repo <@=> option (Just <$> str) (long "repo" <> value Nothing <> metavar "TEXT" <> help "Sets reopsitory that wont to controll.")
+   <: #user <@=> option (Just <$> str) (long "user" <> value Nothing <> metavar "TEXT" <> help "Sets user that wont to controll.")
    <: nil
 
 variantFrom ::

--- a/tool/Main.hs
+++ b/tool/Main.hs
@@ -41,14 +41,22 @@ options = hsequence
 
 subcmdParser :: Parser SubCmd
 subcmdParser = variantFrom
-    $ #new_repo @= newRepoCmdParser `withInfo` "Create repository to team."
+    $ #new_repo         @= newRepoCmdParser    `withInfo` "Create repository for team."
+   <: #new_github_repo  @= singleRepoCmdParser `withInfo` "Create new repository for team in GitHub"
+   <: #init_github_repo @= singleRepoCmdParser `withInfo` "Init repository for team in GitHub"
+   <: #init_ci          @= singleRepoCmdParser `withInfo` "Init CI repository by team repository"
    <: nil
-
 
 newRepoCmdParser :: Parser NewRepoCmd
 newRepoCmdParser = hsequence
-    $ #repo   <@=> option (Just <$> str) (long "repo" <> value Nothing <> metavar "TEXT" <> help "Sets reopsitory that wont to controll.")
-   <: #team   <@=> strArgument (metavar "TEXT" <> help "Sets team that wont to controll.")
+    $ #repo <@=> option (Just <$> str) (long "repo" <> value Nothing <> metavar "TEXT" <> help "Sets reopsitory that wont to controll.")
+   <: #team <@=> strArgument (metavar "TEXT" <> help "Sets team that wont to controll.")
+   <: nil
+
+singleRepoCmdParser :: Parser (Record RepoCmdFields)
+singleRepoCmdParser = hsequence
+    $ #repo <@=> strOption (long "repo" <> metavar "TEXT" <> help "Sets reopsitory that wont to controll.")
+   <: #team <@=> strArgument (metavar "TEXT" <> help "Sets team that wont to controll.")
    <: nil
 
 variantFrom ::

--- a/tool/Main.hs
+++ b/tool/Main.hs
@@ -45,6 +45,7 @@ subcmdParser = variantFrom
    <: #new_github_repo  @= singleRepoCmdParser   `withInfo` "Create new repository for team in GitHub"
    <: #init_github_repo @= singleRepoCmdParser   `withInfo` "Init repository for team in GitHub"
    <: #init_ci          @= singleRepoCmdParser   `withInfo` "Init CI repository by team repository"
+   <: #reset_repo       @= singleRepoCmdParser   `withInfo` "Reset repository for team"
    <: #invite_member    @= inviteMemberCmdParser `withInfo` "Invite Member to Team Repository"
    <: nil
 


### PR DESCRIPTION
- 回答リポジトリの生成の各ステップコマンドを追加
    - GitHub に空リポジトリを作成
    - リポジトリを初期化(問題リポジトリを参照して)
    - 回答のためCIを問題リポジトリに設定
- メンバーを回答リポジトリに招待する
- 回答リポジトリのリセット