### PR TITLE
Slack のリセットボット用の API を追加

### DIFF
--- a/exec/app/Main.hs
+++ b/exec/app/Main.hs
@@ -120,8 +120,7 @@ showVersion v = unwords
   ]
 
 readListEnv :: Read a => String -> [a]
-readListEnv =
-  catMaybes . map (readMaybe . show) . Text.split (== ',') . fromString
+readListEnv = mapMaybe (readMaybe . show) . Text.split (== ',') . fromString
 
 -- HACK
 newtype GitHubKey = GitHubKey (forall result. Servant.GitHub.Webhook.GitHubKey result)

--- a/package.yaml
+++ b/package.yaml
@@ -58,6 +58,7 @@ dependencies:
 - shh
 - yaml >= 0.8.31
 - http-api-data
+- unliftio
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -59,6 +59,7 @@ dependencies:
 - yaml >= 0.8.31
 - http-api-data
 - unliftio
+- wreq
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -57,6 +57,7 @@ dependencies:
 - servant-server
 - shh
 - yaml >= 0.8.31
+- http-api-data
 
 library:
   source-dirs: src

--- a/src/Git/Plantation/API.hs
+++ b/src/Git/Plantation/API.hs
@@ -9,6 +9,7 @@ import           RIO
 
 import qualified Data.Aeson.Text             as Json
 import           Git.Plantation.API.CRUD     (CRUD, crud)
+import           Git.Plantation.API.Slack    (SlackAPI, slackAPI)
 import           Git.Plantation.API.Webhook  (WebhookAPI, webhook)
 import           Git.Plantation.Env          (Plant)
 import           Servant
@@ -23,6 +24,7 @@ type API
    :<|> "static" :> Raw
    :<|> "hook"   :> WebhookAPI
    :<|> "api"    :> CRUD
+   :<|> "slack"  :> SlackAPI
 
 api :: Proxy API
 api = Proxy
@@ -32,6 +34,7 @@ server = indexHtml
     :<|> serveDirectoryFileServer "static"
     :<|> webhook
     :<|> crud
+    :<|> slackAPI
 
 indexHtml :: Plant H.Html
 indexHtml = do

--- a/src/Git/Plantation/API/Slack.hs
+++ b/src/Git/Plantation/API/Slack.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds        #-}
-{-# LANGUAGE LambdaCase       #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE TupleSections    #-}
 {-# LANGUAGE TypeOperators    #-}

--- a/src/Git/Plantation/API/Slack.hs
+++ b/src/Git/Plantation/API/Slack.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TupleSections    #-}
+{-# LANGUAGE TypeOperators    #-}
+
+module Git.Plantation.API.Slack where
+
+import           RIO
+import qualified RIO.List                  as L
+import qualified RIO.Text                  as Text
+
+import           Data.Extensible
+import qualified Git.Plantation.Cmd.Repo   as Cmd
+import           Git.Plantation.Config     (Config)
+import           Git.Plantation.Data       (Problem, Repo, Team)
+import qualified Git.Plantation.Data.Slack as Slack
+import qualified Git.Plantation.Data.Team  as Team
+import           Git.Plantation.Env        (Plant)
+import           Servant
+
+type SlackAPI
+     = "reset-repo" :> ReqBody '[FormUrlEncoded] Slack.OutgoingWebhookData :> Post '[JSON] Slack.Message
+
+slackAPI :: ServerT SlackAPI Plant
+slackAPI
+      = resetRepo
+
+resetRepo :: Slack.OutgoingWebhookData -> Plant Slack.Message
+resetRepo postData = do
+  logInfo $ display $ mconcat
+    [ "[POST] /slack/reset-repo"
+    , " text='", postData ^. #text, "'"
+    , " trigger_word='", postData ^. #trigger_word, "'"
+    ]
+  slackConfig <- asks (view #slack)
+  case verify slackConfig postData of
+    Left err -> returnMessage err
+    Right _  -> resetRepo' $ toMessageBody postData
+  where
+    returnMessage :: MonadIO m => Text -> m Slack.Message
+    returnMessage txt = pure $ #text @= txt <: nil
+
+    resetRepo' :: Text -> Plant Slack.Message
+    resetRepo' text = do
+      config <- asks (view #config)
+      case findInfos config text of
+        Nothing   -> returnMessage "リポジトリが見つからなーい"
+        Just info -> returnMessage =<< reset info
+
+    reset :: (Team, Problem, Repo) -> Plant Text
+    reset (team, problem, repo) = do
+      let success = [team ^. #name, " の ", problem ^. #name, " をリセットしたよ！"]
+      tryAny (Cmd.resetRepo repo team problem) >>= \case
+        Left  e -> logError (display e) >> pure "うーん、なんか失敗しました。"
+        Right _ -> pure $ mconcat success
+
+verify :: Maybe Slack.Config -> Slack.OutgoingWebhookData -> Either Text ()
+verify Nothing _ = Left "Undefined Token..."
+verify (Just config) postData
+  | config ^. #token /= postData ^. #token = Left "Invalid Token..."
+  | otherwise                              = pure ()
+
+toMessageBody :: Slack.OutgoingWebhookData -> Text
+toMessageBody postData =
+  Text.strip $ fromMaybe "" $ Text.stripPrefix (postData ^. #trigger_word) (postData ^. #text)
+
+findInfos :: Config -> Text -> Maybe (Team, Problem, Repo)
+findInfos config txt = do
+  (team, repo) <- L.find (\(_, r) -> Team.repoGithubPath r == Just ghPath) repos
+  problem      <- L.find (\p -> p ^. #id == repo ^. #problem) $ config ^. #problems
+  pure (team, problem, repo)
+  where
+    ghPath = Text.dropSuffix ">" $ Text.dropPrefix "<https://github.com/" txt
+    repos  = concatMap (\t -> (t,) <$> t ^. #repos) $ config ^. #teams

--- a/src/Git/Plantation/Cmd.hs
+++ b/src/Git/Plantation/Cmd.hs
@@ -36,6 +36,7 @@ run opts = do
       plugin  = hsequence
           $ #config  <@=> pure config
          <: #github  <@=> MixGitHub.buildPlugin token
+         <: #slack   <@=> pure Nothing
          <: #work    <@=> MixShell.buildPlugin (opts ^. #work)
          <: #drone   <@=> MixDrone.buildPlugin client Drone.HttpsClient
          <: #webhook <@=> pure (mkWebhookConf (appUrl <> "/hook") secret)

--- a/src/Git/Plantation/Data/Slack.hs
+++ b/src/Git/Plantation/Data/Slack.hs
@@ -1,11 +1,15 @@
-{-# LANGUAGE DataKinds     #-}
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeOperators    #-}
 
 module Git.Plantation.Data.Slack where
 
 import           RIO
+import qualified RIO.Text        as Text
 
+import qualified Data.Aeson      as J
 import           Data.Extensible
+import qualified Network.Wreq    as W
 
 type Config = Record
   '[ "token"          >: Text
@@ -37,3 +41,12 @@ type DisplayLogData = Record
    , "text"         >: Text
    , "command"      >: Text
    ]
+
+mkMessage :: Text -> Message
+mkMessage txt = #text @= txt <: nil
+
+respondMessage :: MonadIO m => SlashCmdData -> Message -> m ()
+respondMessage postData message = do
+  let url = Text.unpack $ postData ^. #response_url
+  _ <- liftIO $ W.post url (J.toJSON message)
+  pure ()

--- a/src/Git/Plantation/Data/Slack.hs
+++ b/src/Git/Plantation/Data/Slack.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE DataKinds     #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Git.Plantation.Data.Slack where
+
+import           RIO
+
+import           Data.Extensible
+
+type Config = Record
+  '[ "token"      >: Text
+   , "user_ids"   >: [Text]
+   ]
+
+type OutgoingWebhookData = Record
+  '[ "token"        >: Text
+   , "team_id"      >: Text
+   , "team_domain"  >: Text
+   , "channel_id"   >: Text
+   , "channel_name" >: Text
+   , "timestamp"    >: Text
+   , "user_id"      >: Text
+   , "user_name"    >: Text
+   , "text"         >: Text
+   , "trigger_word" >: Text
+   ]
+
+type Message = Record '[ "text" >: Text ]

--- a/src/Git/Plantation/Data/Slack.hs
+++ b/src/Git/Plantation/Data/Slack.hs
@@ -8,21 +8,32 @@ import           RIO
 import           Data.Extensible
 
 type Config = Record
-  '[ "token"      >: Text
-   , "user_ids"   >: [Text]
+  '[ "token"          >: Text
+   , "team_id"        >: Text
+   , "channel_ids"    >: [Text]
+   , "user_ids"       >: [Text]
+   , "reset_repo_cmd" >: Text
    ]
 
-type OutgoingWebhookData = Record
+type SlashCmdData = Record
   '[ "token"        >: Text
    , "team_id"      >: Text
    , "team_domain"  >: Text
    , "channel_id"   >: Text
    , "channel_name" >: Text
-   , "timestamp"    >: Text
    , "user_id"      >: Text
    , "user_name"    >: Text
    , "text"         >: Text
-   , "trigger_word" >: Text
+   , "command"      >: Text
+   , "response_url" >: Text
    ]
 
 type Message = Record '[ "text" >: Text ]
+
+type DisplayLogData = Record
+  '[ "team_domain"  >: Text
+   , "channel_name" >: Text
+   , "user_name"    >: Text
+   , "text"         >: Text
+   , "command"      >: Text
+   ]

--- a/src/Git/Plantation/Env.hs
+++ b/src/Git/Plantation/Env.hs
@@ -8,22 +8,24 @@ module Git.Plantation.Env where
 
 import           RIO
 
-import           Data.Aeson            (ToJSON)
-import qualified Data.Aeson.Text       as Json
+import           Data.Aeson                (ToJSON)
+import qualified Data.Aeson.Text           as Json
 import           Data.Extensible
-import qualified Drone.Client          as Drone
+import qualified Drone.Client              as Drone
 import           Git.Plantation.Config
-import           Git.Plantation.Data   (Problem, Repo, Team, User)
-import qualified GitHub.Auth           as GitHub
-import qualified GitHub.Data           as GitHub
-import           Mix.Plugin.Logger     ()
-import qualified RIO.Text.Lazy         as TL
+import           Git.Plantation.Data       (Problem, Repo, Team, User)
+import qualified Git.Plantation.Data.Slack as Slack
+import qualified GitHub.Auth               as GitHub
+import qualified GitHub.Data               as GitHub
+import           Mix.Plugin.Logger         ()
+import qualified RIO.Text.Lazy             as TL
 
 type Plant = RIO Env
 
 type Env = Record
   '[ "config"  >: Config
    , "github"  >: GitHub.Token
+   , "slack"   >: Maybe Slack.Config
    , "work"    >: FilePath
    , "drone"   >: Drone.HttpsClient
    , "webhook" >: WebhookConfig

--- a/src/Orphans.hs
+++ b/src/Orphans.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Orphans () where
+
+import           RIO
+import qualified RIO.List           as L
+import qualified RIO.Text           as Text
+
+import           Data.Extensible
+import           GHC.TypeLits       (symbolVal)
+import           Web.FormUrlEncoded
+import           Web.HttpApiData
+
+instance Forall (KeyValue KnownSymbol FromHttpApiData) xs => FromForm (Record xs) where
+  fromForm form =
+    hgenerateFor (Proxy @ (KeyValue KnownSymbol FromHttpApiData)) $ \m ->
+      let k = Text.pack $ symbolVal (proxyAssocKey m) in Field <$> parseUnique k form
+
+instance FromHttpApiData a => FromHttpApiData (Identity a) where
+  parseUrlPiece = fmap pure . parseUrlPiece

--- a/src/Orphans.hs
+++ b/src/Orphans.hs
@@ -5,7 +5,6 @@
 module Orphans () where
 
 import           RIO
-import qualified RIO.List           as L
 import qualified RIO.Text           as Text
 
 import           Data.Extensible


### PR DESCRIPTION
3秒のタイムアウト対策として `forkIO` で実行を分岐し、結果は先に返している。