### PR TITLE
tool コマンドを2階層化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased changes
 
+* mix パッケージを作成 (#26)
+  * [tonatona](http://hackage.haskell.org/package/tonatona) にインスパイアされた [rio](http://hackage.haskell.org/package/rio) の薄いラッパーパッケージ
+  * rio-logger, [github-client](https://github.com/matsubara0507/github/tree/collaborator-api), [drone-client](https://github.com/matsubara0507/drone-haskell), [shh](http://hackage.haskell.org/package/shh) プラグインも作成
+  * shelly を shh に移行　
+* リセットするSlackボット用のAPIを追加 (#27)
+* shh-cmd パッケージを作成 (#28)
+  * [shh](http://hackage.haskell.org/package/shh) の薄いラッパーパッケージ
+  * よく使うコマンド関数を作成
+* `tool` をサブサブコマンド化 (#29)
+  * `git-plantation-tool (config|problem|member|repo) COMMAND` と指定する形式に変更
+  * 合わせてディレクトリ構造も刷新
+  * `problem` コマンドも追加
+
 ## v0.2.0
 
 * org アカウント以外で config 設定 (#10)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ ref. `.env.template`
 using `git-plantation-tool`:
 
 ```
-$ stack exec -- git-plantation-tool -c .git-plantation.yaml --work .temp new_repo sample
+$ stack exec -- git-plantation-tool -c .git-plantation.yaml --work .temp repo new sample
 ```
 
 ### 4. Run app

--- a/exec/tool/Main.hs
+++ b/exec/tool/Main.hs
@@ -10,26 +10,52 @@
 
 module Main where
 
-import qualified Paths_git_plantation as Meta
+import           Options
+import qualified Paths_git_plantation  as Meta
 import           RIO
 
-import           Configuration.Dotenv (defaultConfig, loadFile)
+import           Configuration.Dotenv  (defaultConfig, loadFile)
 import           Data.Extensible
-import           Data.Version         (Version)
-import qualified Data.Version         as Version
+import           Data.Version          (Version)
+import qualified Data.Version          as Version
 import           Development.GitRev
-import           GHC.TypeLits         hiding (Mod)
-import           Git.Plantation.Cmd
+import qualified Drone.Client          as Drone
+import           GHC.TypeLits          hiding (Mod)
+import           Git.Plantation.Cmd    as Cmd
+import           Git.Plantation.Config (readConfig)
+import           Git.Plantation.Env    (mkWebhookConf)
 import           Options.Applicative
+import           System.Environment    (getEnv)
+
+import qualified Mix
+import qualified Mix.Plugin.Drone      as MixDrone
+import qualified Mix.Plugin.GitHub     as MixGitHub
+import qualified Mix.Plugin.Logger     as MixLogger
+import qualified Mix.Plugin.Shell      as MixShell
 
 main :: IO ()
-main = do
+main = execParser parser >>= \opts -> do
   _ <- tryIO $ loadFile defaultConfig
-  run =<< execParser opts
+  config  <- readConfig (opts ^. #config)
+  token   <- liftIO $ fromString <$> getEnv "GH_TOKEN"
+  secret  <- liftIO $ fromString <$> getEnv "GH_SECRET"
+  appUrl  <- liftIO $ fromString <$> getEnv "APP_SERVER"
+  let client  = #host @= "" <: #port @= Nothing <: #token @= "" <: nil
+      logConf = #handle @= stdout <: #verbose @= (opts ^. #verbose) <: nil
+      plugin  = hsequence
+          $ #config  <@=> pure config
+         <: #github  <@=> MixGitHub.buildPlugin token
+         <: #slack   <@=> pure Nothing
+         <: #work    <@=> MixShell.buildPlugin (opts ^. #work)
+         <: #drone   <@=> MixDrone.buildPlugin client Drone.HttpsClient
+         <: #webhook <@=> pure (mkWebhookConf (appUrl <> "/hook") secret)
+         <: #logger  <@=> MixLogger.buildPlugin logConf
+         <: nil
+  Mix.run plugin $ Cmd.run (opts ^. #subcmd)
   where
-    opts = info (options <**> version Meta.version <**> helper)
-         $ fullDesc
-        <> header "taskpad - operate daily tasks"
+    parser = info (options <**> version Meta.version <**> helper)
+           $ fullDesc
+          <> header "taskpad - operate daily tasks"
 
 options :: Parser Options
 options = hsequence

--- a/exec/tool/Main.hs
+++ b/exec/tool/Main.hs
@@ -1,11 +1,4 @@
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedLabels      #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeApplications      #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE OverloadedLabels #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Main where
@@ -16,11 +9,7 @@ import           RIO
 
 import           Configuration.Dotenv  (defaultConfig, loadFile)
 import           Data.Extensible
-import           Data.Version          (Version)
-import qualified Data.Version          as Version
-import           Development.GitRev
 import qualified Drone.Client          as Drone
-import           GHC.TypeLits          hiding (Mod)
 import           Git.Plantation.Cmd    as Cmd
 import           Git.Plantation.Config (readConfig)
 import           Git.Plantation.Env    (mkWebhookConf)
@@ -56,88 +45,3 @@ main = execParser parser >>= \opts -> do
     parser = info (options <**> version Meta.version <**> helper)
            $ fullDesc
           <> header "taskpad - operate daily tasks"
-
-options :: Parser Options
-options = hsequence
-    $ #verbose <@=> switch (long "verbose" <> short 'v' <> help "Enable verbose mode: verbosity level \"debug\"")
-   <: #config  <@=> strOption (long "config" <> short 'c' <> value "config.yaml" <> metavar "PATH" <> help "Configuration file")
-   <: #work    <@=> strOption (long "work" <> value "~/.git-plantation" <> metavar "PATH" <> help "Work directory to exec git commands")
-   <: #subcmd  <@=> subcmdParser
-   <: nil
-
-subcmdParser :: Parser SubCmd
-subcmdParser = variantFrom
-    $ #verify           @= pure ()               `withInfo` "Verify config file."
-   <: #new_repo         @= newRepoCmdParser      `withInfo` "Create repository for team."
-   <: #new_github_repo  @= singleRepoCmdParser   `withInfo` "Create new repository for team in GitHub"
-   <: #init_github_repo @= singleRepoCmdParser   `withInfo` "Init repository for team in GitHub"
-   <: #setup_webhook    @= singleRepoCmdParser   `withInfo` "Setup GitHub Webhook to team repository"
-   <: #init_ci          @= singleRepoCmdParser   `withInfo` "Init CI repository by team repository"
-   <: #reset_repo       @= singleRepoCmdParser   `withInfo` "Reset repository for team"
-   <: #delete_repo      @= deleteRepoCmdParser   `withInfo` "Delete repository for team."
-   <: #invite_member    @= memberCmdParser       `withInfo` "Invite member to team repository"
-   <: #kick_member      @= memberCmdParser       `withInfo` "Kick member from team repository"
-   <: nil
-
-newRepoCmdParser :: Parser NewRepoCmd
-newRepoCmdParser = hsequence
-    $ #repos              <@=> option comma (long "repos" <> value [] <> metavar "IDS" <> help "Sets reopsitory that want to controll by problem id.")
-   <: #team               <@=> strArgument (metavar "TEXT" <> help "Sets team that want to controll.")
-   <: #skip_create_repo   <@=> switch (long "skip_create_repo" <> help "Flag for skip create new repository in GitHub")
-   <: #skip_init_repo     <@=> switch (long "skip_init_repo" <> help "Flag for skip init repository in GitHub")
-   <: #skip_setup_webhook <@=> switch (long "skip_setup_webhook" <> help "Flag for skip setup GitHub Webhook to repository")
-   <: #skip_init_ci       <@=> switch (long "skip_init_ci" <> help "Flag for skip init CI by repository")
-   <: nil
-
-singleRepoCmdParser :: Parser (Record RepoCmdFields)
-singleRepoCmdParser = hsequence
-    $ #repo <@=> option auto (long "repo" <> metavar "ID" <> help "Sets reopsitory that want to controll by problem id.")
-   <: #team <@=> strArgument (metavar "TEXT" <> help "Sets team that want to controll.")
-   <: nil
-
-deleteRepoCmdParser :: Parser DeleteRepoCmd
-deleteRepoCmdParser = hsequence
-    $ #repos <@=> option comma (long "repos" <> value [] <> metavar "IDS" <> help "Sets reopsitory that want to controll by problem id.")
-   <: #team  <@=> strArgument (metavar "TEXT" <> help "Sets team that want to controll.")
-   <: nil
-
-memberCmdParser :: Parser MemberCmdArg
-memberCmdParser = hsequence
-    $ #team  <@=> strArgument (metavar "TEXT" <> help "Sets team that want to controll.")
-   <: #repos <@=> option comma (long "repos" <> value [] <> metavar "ID" <> help "Sets reopsitory that want to controll by problem id.")
-   <: #user  <@=> option (Just <$> str) (long "user" <> value Nothing <> metavar "TEXT" <> help "Sets user that want to controll.")
-   <: nil
-
-variantFrom ::
-  Forall (KeyIs KnownSymbol) xs => RecordOf ParserInfo xs -> Parser (Variant xs)
-variantFrom = subparser . subcmdVariant
-  where
-    subcmdVariant = hfoldMapWithIndexFor (Proxy @ (KeyIs KnownSymbol)) $ \m x ->
-      let k = symbolVal (proxyAssocKey m)
-      in command k (EmbedAt m . Field . pure <$> getField x)
-
-instance Wrapper ParserInfo where
-  type Repr ParserInfo a = ParserInfo a
-  _Wrapper = id
-
--- |
--- support `--hoge 1,2,3`
-comma :: Read a => ReadM [a]
-comma = maybeReader (\s -> readMaybe $ "[" ++ s ++ "]")
-
-withInfo :: Parser a -> String -> ParserInfo a
-withInfo opts = info (helper <*> opts) . progDesc
-
-version :: Version -> Parser (a -> a)
-version v = infoOption (showVersion v)
-    $ long "version"
-   <> help "Show version"
-
-showVersion :: Version -> String
-showVersion v = unwords
-  [ "Version"
-  , Version.showVersion v ++ ","
-  , "Git revision"
-  , $(gitHash)
-  , "(" ++ $(gitCommitCount) ++ " commits)"
-  ]

--- a/exec/tool/Main.hs
+++ b/exec/tool/Main.hs
@@ -75,8 +75,8 @@ subcmdParser = variantFrom
    <: #init_ci          @= singleRepoCmdParser   `withInfo` "Init CI repository by team repository"
    <: #reset_repo       @= singleRepoCmdParser   `withInfo` "Reset repository for team"
    <: #delete_repo      @= deleteRepoCmdParser   `withInfo` "Delete repository for team."
-   <: #invite_member    @= inviteMemberCmdParser `withInfo` "Invite member to team repository"
-   <: #kick_member      @= kickMemberCmdParser   `withInfo` "Kick member from team repository"
+   <: #invite_member    @= memberCmdParser       `withInfo` "Invite member to team repository"
+   <: #kick_member      @= memberCmdParser       `withInfo` "Kick member from team repository"
    <: nil
 
 newRepoCmdParser :: Parser NewRepoCmd
@@ -97,19 +97,16 @@ singleRepoCmdParser = hsequence
 
 deleteRepoCmdParser :: Parser DeleteRepoCmd
 deleteRepoCmdParser = hsequence
-    $ #repos              <@=> option comma (long "repos" <> value [] <> metavar "IDS" <> help "Sets reopsitory that want to controll by problem id.")
-   <: #team               <@=> strArgument (metavar "TEXT" <> help "Sets team that want to controll.")
+    $ #repos <@=> option comma (long "repos" <> value [] <> metavar "IDS" <> help "Sets reopsitory that want to controll by problem id.")
+   <: #team  <@=> strArgument (metavar "TEXT" <> help "Sets team that want to controll.")
    <: nil
 
-inviteMemberCmdParser :: Parser InviteMemberCmd
-inviteMemberCmdParser = hsequence
+memberCmdParser :: Parser MemberCmdArg
+memberCmdParser = hsequence
     $ #team  <@=> strArgument (metavar "TEXT" <> help "Sets team that want to controll.")
    <: #repos <@=> option comma (long "repos" <> value [] <> metavar "ID" <> help "Sets reopsitory that want to controll by problem id.")
    <: #user  <@=> option (Just <$> str) (long "user" <> value Nothing <> metavar "TEXT" <> help "Sets user that want to controll.")
    <: nil
-
-kickMemberCmdParser :: Parser KickMemberCmd
-kickMemberCmdParser = inviteMemberCmdParser
 
 variantFrom ::
   Forall (KeyIs KnownSymbol) xs => RecordOf ParserInfo xs -> Parser (Variant xs)

--- a/exec/tool/Options.hs
+++ b/exec/tool/Options.hs
@@ -3,19 +3,18 @@
 {-# LANGUAGE TypeOperators    #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Git.Plantation.Cmd.Options where
+module Options where
 
 import           RIO
-import qualified RIO.List                  as L
+import qualified RIO.List                 as L
 
 import           Data.Extensible
-import           Git.Plantation.Cmd.Member
-import           Git.Plantation.Cmd.Repo
-import           Git.Plantation.Cmd.Run
-import           Git.Plantation.Config     as Config
-import           Git.Plantation.Data       (Problem, Team)
-import qualified Git.Plantation.Data.Team  as Team
+import           Git.Plantation.Cmd
+import           Git.Plantation.Config    as Config
+import           Git.Plantation.Data      (Problem, Team)
+import qualified Git.Plantation.Data.Team as Team
 import           Git.Plantation.Env
+
 
 type Options = Record
   '[ "verbose" >: Bool

--- a/exec/tool/Options.hs
+++ b/exec/tool/Options.hs
@@ -90,8 +90,13 @@ memberCmdArgParser = hsequence
 
 problemCmdParser :: Parser ProblemCmd
 problemCmdParser = fmap ProblemCmd . variantFrom
-    $ #show @= pure () `withInfo` "Display proble info."
+    $ #show @= problemCmdArgParser `withInfo` "Display proble info."
    <: nil
+
+problemCmdArgParser :: Parser ProblemCmdArg
+problemCmdArgParser = hsequence
+   $ #problems <@=> option comma (long "problems" <> value [] <> metavar "IDS" <> help "Set problem ids that want to manage.")
+  <: nil
 
 variantFrom ::
   Forall (KeyIs KnownSymbol) xs => RecordOf ParserInfo xs -> Parser (Variant xs)

--- a/exec/tool/Options.hs
+++ b/exec/tool/Options.hs
@@ -34,8 +34,8 @@ type SubCmdFields =
    , "init_ci"          >: InitCICmd
    , "reset_repo"       >: ResetRepoCmd
    , "delete_repo"      >: DeleteRepoCmd
-   , "invite_member"    >: InviteMemberCmd
-   , "kick_member"      >: KickMemberCmd
+   , "invite_member"    >: MemberCmdArg
+   , "kick_member"      >: MemberCmdArg
    ]
 
 instance Run ("verify" >: ()) where
@@ -97,18 +97,8 @@ instance Run ("delete_repo" >: DeleteRepoCmd) where
       (Just team', [])   -> forM_ (conf ^. #problems) (tryAnyWithLogError . deleteRepo team')
       (Just team', pids) -> forM_ pids $ actByProblemId deleteRepo team'
 
-instance Run ("invite_member" >: InviteMemberCmd) where
-  run' _ args = do
-    conf <- asks (view #config)
-    let team = L.find (\t -> t ^. #name == args ^. #team) $ conf ^. #teams
-    case team of
-      Nothing    -> logError $ "team is not found: " <> display (args ^. #team)
-      Just team' -> actForMember inviteUserToRepo args team'
+instance Run ("invite_member" >: MemberCmdArg) where
+  run' _ = actForMember inviteUserToRepo
 
-instance Run ("kick_member" >: KickMemberCmd) where
-  run' _ args = do
-    conf <- asks (view #config)
-    let team = L.find (\t -> t ^. #name == args ^. #team) $ conf ^. #teams
-    case team of
-      Nothing    -> logError $ "team is not found: " <> display (args ^. #team)
-      Just team' -> actForMember kickUserFromRepo args team'
+instance Run ("kick_member" >: MemberCmdArg) where
+  run' _ = actForMember kickUserFromRepo

--- a/exec/tool/Options.hs
+++ b/exec/tool/Options.hs
@@ -50,13 +50,29 @@ configCmdParser = fmap ConfigCmd . variantFrom
 
 repoCmdParser :: Parser RepoCmd
 repoCmdParser = fmap RepoCmd . variantFrom
-    $ #new           @= newRepoCmdParser    `withInfo` "Create repository for team."
-   <: #new_github    @= singleRepoCmdParser `withInfo` "Create new repository for team in GitHub"
-   <: #init_github   @= singleRepoCmdParser `withInfo` "Init repository for team in GitHub"
-   <: #setup_webhook @= singleRepoCmdParser `withInfo` "Setup GitHub Webhook to team repository"
-   <: #init_ci       @= singleRepoCmdParser `withInfo` "Init CI repository by team repository"
-   <: #reset         @= singleRepoCmdParser `withInfo` "Reset repository for team"
-   <: #delete        @= deleteRepoCmdParser `withInfo` "Delete repository for team."
+    $ #new           @= newRepoCmdParser `withInfo` "Create repository for team."
+   <: #new_github    @= repoCmdArgParser `withInfo` "Create new repository for team in GitHub"
+   <: #init_github   @= repoCmdArgParser `withInfo` "Init repository for team in GitHub"
+   <: #setup_webhook @= repoCmdArgParser `withInfo` "Setup GitHub Webhook to team repository"
+   <: #init_ci       @= repoCmdArgParser `withInfo` "Init CI repository by team repository"
+   <: #reset         @= repoCmdArgParser `withInfo` "Reset repository for team"
+   <: #delete        @= repoCmdArgParser `withInfo` "Delete repository for team."
+   <: nil
+  where
+    newRepoCmdParser = (,) <$> repoCmdArgParser <*> newRepoFlags
+
+repoCmdArgParser :: Parser RepoCmdArg
+repoCmdArgParser = hsequence
+    $ #repos <@=> option comma (long "repos" <> value [] <> metavar "IDS" <> help "Sets reopsitory that want to controll by problem id.")
+   <: #team  <@=> strArgument (metavar "TEXT" <> help "Sets team that want to controll.")
+   <: nil
+
+newRepoFlags :: Parser NewRepoFlags
+newRepoFlags = hsequence
+    $ #skip_create_repo   <@=> switch (long "skip_create_repo" <> help "Flag for skip create new repository in GitHub")
+   <: #skip_init_repo     <@=> switch (long "skip_init_repo" <> help "Flag for skip init repository in GitHub")
+   <: #skip_setup_webhook <@=> switch (long "skip_setup_webhook" <> help "Flag for skip setup GitHub Webhook to repository")
+   <: #skip_init_ci       <@=> switch (long "skip_init_ci" <> help "Flag for skip init CI by repository")
    <: nil
 
 memberCmdParser :: Parser MemberCmd
@@ -75,28 +91,6 @@ memberCmdArgParser = hsequence
 problemCmdParser :: Parser ProblemCmd
 problemCmdParser = fmap ProblemCmd . variantFrom
     $ #show @= pure () `withInfo` "Display proble info."
-   <: nil
-
-newRepoCmdParser :: Parser NewRepoCmd
-newRepoCmdParser = hsequence
-    $ #repos              <@=> option comma (long "repos" <> value [] <> metavar "IDS" <> help "Sets reopsitory that want to controll by problem id.")
-   <: #team               <@=> strArgument (metavar "TEXT" <> help "Sets team that want to controll.")
-   <: #skip_create_repo   <@=> switch (long "skip_create_repo" <> help "Flag for skip create new repository in GitHub")
-   <: #skip_init_repo     <@=> switch (long "skip_init_repo" <> help "Flag for skip init repository in GitHub")
-   <: #skip_setup_webhook <@=> switch (long "skip_setup_webhook" <> help "Flag for skip setup GitHub Webhook to repository")
-   <: #skip_init_ci       <@=> switch (long "skip_init_ci" <> help "Flag for skip init CI by repository")
-   <: nil
-
-singleRepoCmdParser :: Parser (Record RepoCmdFields)
-singleRepoCmdParser = hsequence
-    $ #repo <@=> option auto (long "repo" <> metavar "ID" <> help "Sets reopsitory that want to controll by problem id.")
-   <: #team <@=> strArgument (metavar "TEXT" <> help "Sets team that want to controll.")
-   <: nil
-
-deleteRepoCmdParser :: Parser DeleteRepoCmd
-deleteRepoCmdParser = hsequence
-    $ #repos <@=> option comma (long "repos" <> value [] <> metavar "IDS" <> help "Sets reopsitory that want to controll by problem id.")
-   <: #team  <@=> strArgument (metavar "TEXT" <> help "Sets team that want to controll.")
    <: nil
 
 variantFrom ::

--- a/exec/tool/SubCmd.hs
+++ b/exec/tool/SubCmd.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeOperators    #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module SubCmd
+  ( module X
+  , SubCmd
+  ) where
+
+import           SubCmd.Config      as X (ConfigCmd (..))
+import           SubCmd.Member      as X (MemberCmd (..))
+import           SubCmd.Problem     as X (ProblemCmd (..))
+import           SubCmd.Repo        as X (RepoCmd (..))
+
+import           Data.Extensible
+import           Git.Plantation.Cmd
+
+
+type SubCmd = Variant
+  '[ "config"  >: ConfigCmd
+   , "repo"    >: RepoCmd
+   , "member"  >: MemberCmd
+   , "problem" >: ProblemCmd
+   ]
+
+instance Run ("config" >: ConfigCmd) where
+  run' _ (ConfigCmd cmd) = run cmd
+
+instance Run ("repo" >: RepoCmd) where
+  run' _ (RepoCmd cmd) = run cmd
+
+instance Run ("member" >: MemberCmd) where
+  run' _ (MemberCmd cmd) = run cmd
+
+instance Run ("problem" >: ProblemCmd) where
+  run' _ (ProblemCmd cmd) = run cmd

--- a/exec/tool/SubCmd/Config.hs
+++ b/exec/tool/SubCmd/Config.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeOperators    #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module SubCmd.Config
+  ( ConfigCmd (..)
+  ) where
+
+import           RIO
+
+import           Data.Extensible
+import           Git.Plantation.Cmd
+import           Git.Plantation.Config as Config
+
+newtype ConfigCmd = ConfigCmd (Variant CmdFields)
+
+type CmdFields =
+  '[ "verify" >: ()
+   ]
+
+instance Run ("verify" >: ()) where
+  run' _ _ = do
+    conf <- asks (view #config)
+    case Config.verify conf of
+      Left err -> logError $ "invalid config: " <> display err
+      Right _  -> logInfo "valid config"

--- a/exec/tool/SubCmd/Member.hs
+++ b/exec/tool/SubCmd/Member.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE DataKinds     #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module SubCmd.Member
+  ( MemberCmd (..)
+  ) where
+
+import           Data.Extensible
+import           Git.Plantation.Cmd.Member
+import           Git.Plantation.Cmd.Run
+
+newtype MemberCmd = MemberCmd (Variant CmdFields)
+
+type CmdFields =
+  '[ "invite" >: MemberCmdArg
+   , "kick"   >: MemberCmdArg
+   ]
+
+instance Run ("invite" >: MemberCmdArg) where
+  run' _ = actForMember inviteUserToRepo
+
+instance Run ("kick" >: MemberCmdArg) where
+  run' _ = actForMember kickUserFromRepo

--- a/exec/tool/SubCmd/Problem.hs
+++ b/exec/tool/SubCmd/Problem.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE DataKinds     #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module SubCmd.Problem
+  ( ProblemCmd (..)
+  ) where
+
+import           RIO
+
+import           Data.Extensible
+import           Git.Plantation.Cmd
+
+newtype ProblemCmd = ProblemCmd (Variant CmdField)
+
+type CmdField =
+  '[ "show" >: ()
+   ]
+
+instance Run ("show" >: ()) where
+  run' _ = undefined

--- a/exec/tool/SubCmd/Problem.hs
+++ b/exec/tool/SubCmd/Problem.hs
@@ -6,16 +6,15 @@ module SubCmd.Problem
   ( ProblemCmd (..)
   ) where
 
-import           RIO
-
 import           Data.Extensible
-import           Git.Plantation.Cmd
+import           Git.Plantation.Cmd.Problem
+import           Git.Plantation.Cmd.Run
 
 newtype ProblemCmd = ProblemCmd (Variant CmdField)
 
 type CmdField =
-  '[ "show" >: ()
+  '[ "show" >: ProblemCmdArg
    ]
 
-instance Run ("show" >: ()) where
-  run' _ = undefined
+instance Run ("show" >: ProblemCmdArg) where
+  run' _ = actForProblem showProblem

--- a/exec/tool/SubCmd/Repo.hs
+++ b/exec/tool/SubCmd/Repo.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeOperators    #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module SubCmd.Repo
+  ( RepoCmd (..)
+  ) where
+
+import           RIO
+import qualified RIO.List                 as L
+
+import           Data.Extensible
+import           Git.Plantation.Cmd.Repo
+import           Git.Plantation.Cmd.Run
+import           Git.Plantation.Data      (Problem, Team)
+import qualified Git.Plantation.Data.Team as Team
+import           Git.Plantation.Env
+
+newtype RepoCmd = RepoCmd (Variant CmdFields)
+
+type CmdFields =
+  '[ "new"           >: NewRepoCmd
+   , "new_github"    >: NewGitHubRepoCmd
+   , "init_github"   >: InitGitHubRepoCmd
+   , "setup_webhook" >: SetupWebhookCmd
+   , "init_ci"       >: InitCICmd
+   , "reset"         >: ResetRepoCmd
+   , "delete"        >: DeleteRepoCmd
+   ]
+
+instance Run ("new" >: NewRepoCmd) where
+  run' _ args = do
+    conf <- asks (view #config)
+    let team  = L.find (\t -> t ^. #name == args ^. #team) $ conf ^. #teams
+        flags = shrink args
+    case (team, args ^. #repos) of
+      (Nothing, _)       -> logError $ "team is not found: " <> display (args ^. #team)
+      (Just team', [])   -> forM_ (conf ^. #problems) (tryAnyWithLogError . createRepo flags team')
+      (Just team', pids) -> forM_ pids $ actByProblemId (createRepo flags) team'
+
+instance Run ("new_github" >: NewGitHubRepoCmd) where
+  run' _ = runRepoCmd $ \team problem -> do
+    info <- Team.lookupRepo problem team `fromJustWithThrow` UndefinedTeamProblem team problem
+    createRepoInGitHub info team problem
+
+instance Run ("init_github" >: InitGitHubRepoCmd) where
+  run' _ = runRepoCmd $ \team problem -> do
+    info <- Team.lookupRepo problem team `fromJustWithThrow` UndefinedTeamProblem team problem
+    initRepoInGitHub info team problem
+
+instance Run ("setup_webhook" >: SetupWebhookCmd) where
+  run' _ = runRepoCmd $ \team problem -> do
+    info <- Team.lookupRepo problem team `fromJustWithThrow` UndefinedTeamProblem team problem
+    setupWebhook info
+
+instance Run ("init_ci" >: InitCICmd) where
+  run' _ = runRepoCmd $ \team problem -> do
+    info <- Team.lookupRepo problem team `fromJustWithThrow` UndefinedTeamProblem team problem
+    initProblemCI info team problem
+
+instance Run ("reset" >: ResetRepoCmd) where
+  run' _ = runRepoCmd $ \team problem -> do
+    info <- Team.lookupRepo problem team `fromJustWithThrow` UndefinedTeamProblem team problem
+    resetRepo info team problem
+
+runRepoCmd :: (Team -> Problem -> Plant ()) -> Record RepoCmdFields -> Plant ()
+runRepoCmd act args = do
+  conf <- asks (view #config)
+  let team = L.find (\t -> t ^. #name == args ^. #team) $ conf ^. #teams
+  case (team, args ^. #repo) of
+    (Nothing, _)      -> logError $ "team is not found: " <> display (args ^. #team)
+    (Just team', pid) -> actByProblemId act team' pid
+
+instance Run ("delete" >: DeleteRepoCmd) where
+  run' _ args = do
+    conf <- asks (view #config)
+    let team = L.find (\t -> t ^. #name == args ^. #team) $ conf ^. #teams
+    case (team, args ^. #repos) of
+      (Nothing, _)       -> logError $ "team is not found: " <> display (args ^. #team)
+      (Just team', [])   -> forM_ (conf ^. #problems) (tryAnyWithLogError . deleteRepo team')
+      (Just team', pids) -> forM_ pids $ actByProblemId deleteRepo team'

--- a/exec/tool/SubCmd/Repo.hs
+++ b/exec/tool/SubCmd/Repo.hs
@@ -7,76 +7,39 @@ module SubCmd.Repo
   ( RepoCmd (..)
   ) where
 
-import           RIO
-import qualified RIO.List                 as L
-
 import           Data.Extensible
 import           Git.Plantation.Cmd.Repo
 import           Git.Plantation.Cmd.Run
-import           Git.Plantation.Data      (Problem, Team)
-import qualified Git.Plantation.Data.Team as Team
-import           Git.Plantation.Env
 
 newtype RepoCmd = RepoCmd (Variant CmdFields)
 
 type CmdFields =
-  '[ "new"           >: NewRepoCmd
-   , "new_github"    >: NewGitHubRepoCmd
-   , "init_github"   >: InitGitHubRepoCmd
-   , "setup_webhook" >: SetupWebhookCmd
-   , "init_ci"       >: InitCICmd
-   , "reset"         >: ResetRepoCmd
-   , "delete"        >: DeleteRepoCmd
+  '[ "new"           >: (RepoCmdArg, NewRepoFlags)
+   , "new_github"    >: RepoCmdArg
+   , "init_github"   >: RepoCmdArg
+   , "setup_webhook" >: RepoCmdArg
+   , "init_ci"       >: RepoCmdArg
+   , "reset"         >: RepoCmdArg
+   , "delete"        >: RepoCmdArg
    ]
 
-instance Run ("new" >: NewRepoCmd) where
-  run' _ args = do
-    conf <- asks (view #config)
-    let team  = L.find (\t -> t ^. #name == args ^. #team) $ conf ^. #teams
-        flags = shrink args
-    case (team, args ^. #repos) of
-      (Nothing, _)       -> logError $ "team is not found: " <> display (args ^. #team)
-      (Just team', [])   -> forM_ (conf ^. #problems) (tryAnyWithLogError . createRepo flags team')
-      (Just team', pids) -> forM_ pids $ actByProblemId (createRepo flags) team'
+instance Run ("new" >: (RepoCmdArg, NewRepoFlags)) where
+  run' _ (args, flags) = actForRepo (createRepo flags) args
 
-instance Run ("new_github" >: NewGitHubRepoCmd) where
-  run' _ = runRepoCmd $ \team problem -> do
-    info <- Team.lookupRepo problem team `fromJustWithThrow` UndefinedTeamProblem team problem
-    createRepoInGitHub info team problem
+instance Run ("new_github" >: RepoCmdArg) where
+  run' _ = actForRepo createRepoInGitHub
 
-instance Run ("init_github" >: InitGitHubRepoCmd) where
-  run' _ = runRepoCmd $ \team problem -> do
-    info <- Team.lookupRepo problem team `fromJustWithThrow` UndefinedTeamProblem team problem
-    initRepoInGitHub info team problem
+instance Run ("init_github" >: RepoCmdArg) where
+  run' _ = actForRepo initRepoInGitHub
 
-instance Run ("setup_webhook" >: SetupWebhookCmd) where
-  run' _ = runRepoCmd $ \team problem -> do
-    info <- Team.lookupRepo problem team `fromJustWithThrow` UndefinedTeamProblem team problem
-    setupWebhook info
+instance Run ("setup_webhook" >: RepoCmdArg) where
+  run' _ = actForRepo setupWebhook
 
-instance Run ("init_ci" >: InitCICmd) where
-  run' _ = runRepoCmd $ \team problem -> do
-    info <- Team.lookupRepo problem team `fromJustWithThrow` UndefinedTeamProblem team problem
-    initProblemCI info team problem
+instance Run ("init_ci" >: RepoCmdArg) where
+  run' _ = actForRepo initProblemCI
 
-instance Run ("reset" >: ResetRepoCmd) where
-  run' _ = runRepoCmd $ \team problem -> do
-    info <- Team.lookupRepo problem team `fromJustWithThrow` UndefinedTeamProblem team problem
-    resetRepo info team problem
+instance Run ("reset" >: RepoCmdArg) where
+  run' _ = actForRepo resetRepo
 
-runRepoCmd :: (Team -> Problem -> Plant ()) -> Record RepoCmdFields -> Plant ()
-runRepoCmd act args = do
-  conf <- asks (view #config)
-  let team = L.find (\t -> t ^. #name == args ^. #team) $ conf ^. #teams
-  case (team, args ^. #repo) of
-    (Nothing, _)      -> logError $ "team is not found: " <> display (args ^. #team)
-    (Just team', pid) -> actByProblemId act team' pid
-
-instance Run ("delete" >: DeleteRepoCmd) where
-  run' _ args = do
-    conf <- asks (view #config)
-    let team = L.find (\t -> t ^. #name == args ^. #team) $ conf ^. #teams
-    case (team, args ^. #repos) of
-      (Nothing, _)       -> logError $ "team is not found: " <> display (args ^. #team)
-      (Just team', [])   -> forM_ (conf ^. #problems) (tryAnyWithLogError . deleteRepo team')
-      (Just team', pids) -> forM_ pids $ actByProblemId deleteRepo team'
+instance Run ("delete" >: RepoCmdArg) where
+  run' _ = actForRepo deleteRepo

--- a/libs/mix/src/Mix/Plugin/Config.hs
+++ b/libs/mix/src/Mix/Plugin/Config.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedLabels      #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Mix.Plugin.Config
+  ( HasConfig (..)
+  , buildPlugin
+  ) where
+
+import           RIO
+
+import           Data.Extensible
+import           Mix.Plugin      (Plugin)
+
+buildPlugin :: MonadIO m => c -> Plugin a m c
+buildPlugin = pure
+
+class HasConfig c env where
+  configL :: Lens' env c
+
+instance Associate "config" c xs => HasConfig c (Record xs) where
+  configL = lens (view #config) (\x y -> x & #config `set` y)

--- a/libs/mix/src/Mix/Plugin/Config.hs
+++ b/libs/mix/src/Mix/Plugin/Config.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedLabels      #-}
 {-# LANGUAGE TypeOperators         #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 
 module Mix.Plugin.Config
   ( HasConfig (..)

--- a/src/Git/Plantation/API/Slack.hs
+++ b/src/Git/Plantation/API/Slack.hs
@@ -59,7 +59,7 @@ resetRepo postData = do
     reset :: (Team, Problem, Repo) -> Plant Text
     reset (team, problem, repo) = do
       let success = [team ^. #name, " の ", problem ^. #name, " をリセットしました！"]
-      tryIO (Cmd.resetRepo repo team problem) >>= \case
+      tryIO (Cmd.resetRepo $ #repo @= repo <: #team @= team <: nil) >>= \case
         Left err -> logError (display err) >> pure "うーん、なんか失敗したみたい..."
         Right _  -> pure $ mconcat success
 

--- a/src/Git/Plantation/Cmd.hs
+++ b/src/Git/Plantation/Cmd.hs
@@ -11,11 +11,12 @@ module Git.Plantation.Cmd
 import           RIO
 
 import           Data.Extensible
-import           Git.Plantation.Cmd.Arg    as X
-import           Git.Plantation.Cmd.Member as X
-import           Git.Plantation.Cmd.Repo   as X
-import           Git.Plantation.Cmd.Run    as X
-import           Git.Plantation.Env        (Plant)
+import           Git.Plantation.Cmd.Arg     as X
+import           Git.Plantation.Cmd.Member  as X
+import           Git.Plantation.Cmd.Problem as X
+import           Git.Plantation.Cmd.Repo    as X
+import           Git.Plantation.Cmd.Run     as X
+import           Git.Plantation.Env         (Plant)
 
 run :: Forall Run xs => Variant xs -> Plant ()
 run = matchField (htabulateFor (Proxy @ Run) $ \m -> Field (Match $ run' m . runIdentity))

--- a/src/Git/Plantation/Cmd.hs
+++ b/src/Git/Plantation/Cmd.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE DataKinds        #-}
-{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators    #-}
 
@@ -11,37 +11,10 @@ module Git.Plantation.Cmd
 import           RIO
 
 import           Data.Extensible
-import qualified Drone.Client               as Drone
-import           Git.Plantation.Cmd.Member  as X
-import           Git.Plantation.Cmd.Options as X
-import           Git.Plantation.Cmd.Repo    as X
-import           Git.Plantation.Cmd.Run     as X
-import           Git.Plantation.Config      (readConfig)
-import           Git.Plantation.Env         (mkWebhookConf)
-import qualified Mix
-import qualified Mix.Plugin.Drone           as MixDrone
-import qualified Mix.Plugin.GitHub          as MixGitHub
-import qualified Mix.Plugin.Logger          as MixLogger
-import qualified Mix.Plugin.Shell           as MixShell
-import           System.Environment         (getEnv)
+import           Git.Plantation.Cmd.Member as X
+import           Git.Plantation.Cmd.Repo   as X
+import           Git.Plantation.Cmd.Run    as X
+import           Git.Plantation.Env        (Plant)
 
-run :: MonadUnliftIO m => Options -> m ()
-run opts = do
-  config  <- readConfig (opts ^. #config)
-  token   <- liftIO $ fromString <$> getEnv "GH_TOKEN"
-  secret  <- liftIO $ fromString <$> getEnv "GH_SECRET"
-  appUrl  <- liftIO $ fromString <$> getEnv "APP_SERVER"
-  let client  = #host @= "" <: #port @= Nothing <: #token @= "" <: nil
-      logConf = #handle @= stdout <: #verbose @= (opts ^. #verbose) <: nil
-      plugin  = hsequence
-          $ #config  <@=> pure config
-         <: #github  <@=> MixGitHub.buildPlugin token
-         <: #slack   <@=> pure Nothing
-         <: #work    <@=> MixShell.buildPlugin (opts ^. #work)
-         <: #drone   <@=> MixDrone.buildPlugin client Drone.HttpsClient
-         <: #webhook <@=> pure (mkWebhookConf (appUrl <> "/hook") secret)
-         <: #logger  <@=> MixLogger.buildPlugin logConf
-         <: nil
-  Mix.run plugin $ matchField
-      (htabulateFor (Proxy @ Run) $ \m -> Field (Match $ run' m . runIdentity))
-      (opts ^. #subcmd)
+run :: Forall Run xs => Variant xs -> Plant ()
+run = matchField (htabulateFor (Proxy @ Run) $ \m -> Field (Match $ run' m . runIdentity))

--- a/src/Git/Plantation/Cmd.hs
+++ b/src/Git/Plantation/Cmd.hs
@@ -11,6 +11,7 @@ module Git.Plantation.Cmd
 import           RIO
 
 import           Data.Extensible
+import           Git.Plantation.Cmd.Arg    as X
 import           Git.Plantation.Cmd.Member as X
 import           Git.Plantation.Cmd.Repo   as X
 import           Git.Plantation.Cmd.Run    as X

--- a/src/Git/Plantation/Cmd/Arg.hs
+++ b/src/Git/Plantation/Cmd/Arg.hs
@@ -1,0 +1,18 @@
+module Git.Plantation.Cmd.Arg
+  ( module X
+  , mapMaybeWithDefault
+  , filterByIdWithDefault
+  ) where
+
+import           RIO
+
+import           Git.Plantation.Cmd.Arg.Internal as X (ErrMsg, IdArg (..),
+                                                       findByIdWith)
+import           Git.Plantation.Cmd.Arg.Problem  as X
+import           Git.Plantation.Cmd.Arg.Team     as X
+
+mapMaybeWithDefault :: [b] -> (a -> Maybe b) -> [a] -> [b]
+mapMaybeWithDefault bs f as = if null as then bs else mapMaybe f as
+
+filterByIdWithDefault :: IdArg id a => [a] -> [id] -> [a]
+filterByIdWithDefault xs = mapMaybeWithDefault xs (`findById` xs)

--- a/src/Git/Plantation/Cmd/Arg.hs
+++ b/src/Git/Plantation/Cmd/Arg.hs
@@ -2,8 +2,6 @@ module Git.Plantation.Cmd.Arg
   ( module X
   ) where
 
-import           RIO
-
 import           Git.Plantation.Cmd.Arg.Internal as X (ErrMsg, IdArg (..),
                                                        findByIdWith)
 import           Git.Plantation.Cmd.Arg.Problem  as X

--- a/src/Git/Plantation/Cmd/Arg.hs
+++ b/src/Git/Plantation/Cmd/Arg.hs
@@ -1,7 +1,5 @@
 module Git.Plantation.Cmd.Arg
   ( module X
-  , mapMaybeWithDefault
-  , filterByIdWithDefault
   ) where
 
 import           RIO
@@ -10,9 +8,3 @@ import           Git.Plantation.Cmd.Arg.Internal as X (ErrMsg, IdArg (..),
                                                        findByIdWith)
 import           Git.Plantation.Cmd.Arg.Problem  as X
 import           Git.Plantation.Cmd.Arg.Team     as X
-
-mapMaybeWithDefault :: [b] -> (a -> Maybe b) -> [a] -> [b]
-mapMaybeWithDefault bs f as = if null as then bs else mapMaybe f as
-
-filterByIdWithDefault :: IdArg id a => [a] -> [id] -> [a]
-filterByIdWithDefault xs = mapMaybeWithDefault xs (`findById` xs)

--- a/src/Git/Plantation/Cmd/Arg/Internal.hs
+++ b/src/Git/Plantation/Cmd/Arg/Internal.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE DataKinds              #-}
+{-# LANGUAGE FlexibleContexts       #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE TypeOperators          #-}
+
+module Git.Plantation.Cmd.Arg.Internal where
+
+import           RIO
+
+import           Data.Extensible
+import           Git.Plantation.Config
+import           Mix.Plugin.Config     (HasConfig (..))
+
+class IdArg id a | id -> a where
+  findById :: id -> [a] -> Maybe a
+  errMsg :: id -> ErrMsg
+
+type ErrMsg = Record
+  '[ "message" >: Text
+   , "id" >: Text
+   ]
+
+asksConfig :: (HasConfig Config env, MonadReader env m) => m Config
+asksConfig = view configL
+
+findByIdWith :: (IdArg id a, HasConfig Config env, MonadReader env m)
+  => (Config -> [a]) -> id -> m (Maybe a)
+findByIdWith f idx = findById idx . f <$> asksConfig

--- a/src/Git/Plantation/Cmd/Arg/Problem.hs
+++ b/src/Git/Plantation/Cmd/Arg/Problem.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DerivingVia            #-}
+{-# LANGUAGE FlexibleContexts       #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE OverloadedLabels       #-}
+
+module Git.Plantation.Cmd.Arg.Problem where
+
+import           RIO
+import qualified RIO.List                        as L
+
+import           Data.Coerce                     (coerce)
+import           Data.Extensible
+import           Git.Plantation.Cmd.Arg.Internal
+import           Git.Plantation.Data.Problem
+
+newtype ProblemId = ProblemId Int
+  deriving (Read) via Int
+
+instance IdArg ProblemId Problem where
+  findById idx = L.find (\p -> p ^. #id == coerce idx)
+  errMsg idx
+      = #message @= "not found by config: Problem"
+     <: #id @= tshow (coerce idx :: Int)
+     <: nil

--- a/src/Git/Plantation/Cmd/Arg/Team.hs
+++ b/src/Git/Plantation/Cmd/Arg/Team.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE DerivingVia            #-}
+{-# LANGUAGE FlexibleContexts       #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+{-# LANGUAGE OverloadedLabels       #-}
+
+module Git.Plantation.Cmd.Arg.Team where
+
+import           RIO
+import qualified RIO.List                        as L
+
+import           Data.Coerce                     (coerce)
+import           Data.Extensible
+import           Git.Plantation.Cmd.Arg.Internal
+import           Git.Plantation.Data.Team
+
+newtype TeamId = TeamId Text
+  deriving (IsString) via Text
+
+instance IdArg TeamId Team where
+  findById idx = L.find (\t -> t ^. #id == coerce idx)
+  errMsg idx
+      = #message @= "not found by config: Team"
+     <: #id @= coerce idx
+     <: nil
+
+newtype RepoId = RepoId Int -- same problem id
+  deriving (Read) via Int
+
+instance IdArg RepoId Repo where
+  findById idx = L.find (\r -> r ^. #problem == coerce idx)
+  errMsg idx
+      = #message @= "not found by config: Repo"
+     <: #id @= tshow (coerce idx :: Int)
+     <: nil
+
+newtype UserId = UserId Text -- github id
+  deriving (IsString) via Text
+
+instance IdArg UserId User where
+  findById idx = L.find (\u -> u ^. #github == coerce idx)
+  errMsg idx
+      = #message @= "not found by config: User"
+     <: #id @= coerce idx
+     <: nil

--- a/src/Git/Plantation/Cmd/Member.hs
+++ b/src/Git/Plantation/Cmd/Member.hs
@@ -3,7 +3,13 @@
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE TypeOperators    #-}
 
-module Git.Plantation.Cmd.Member where
+module Git.Plantation.Cmd.Member
+  ( MemberCmdArg
+  , MemberArg
+  , actForMember
+  , inviteUserToRepo
+  , kickUserFromRepo
+  ) where
 
 import           RIO
 

--- a/src/Git/Plantation/Cmd/Member.hs
+++ b/src/Git/Plantation/Cmd/Member.hs
@@ -17,7 +17,6 @@ import           Git.Plantation.Env
 import           GitHub.Data.Name                     (mkName)
 import qualified GitHub.Endpoints.Repos.Collaborators as GitHub
 import qualified Mix.Plugin.GitHub                    as MixGitHub
-import           Mix.Plugin.Logger                    as MixLogger
 
 type MemberCmdArg = Record
   '[ "team"  >: TeamId

--- a/src/Git/Plantation/Cmd/Member.hs
+++ b/src/Git/Plantation/Cmd/Member.hs
@@ -7,6 +7,7 @@ module Git.Plantation.Cmd.Member where
 import           RIO
 
 import           Data.Extensible
+import           Git.Plantation.Cmd.Arg
 import           Git.Plantation.Cmd.Repo              (repoGithub,
                                                        splitRepoName)
 import           Git.Plantation.Data
@@ -15,57 +16,60 @@ import           GitHub.Data.Name                     (mkName)
 import qualified GitHub.Endpoints.Repos.Collaborators as GitHub
 import qualified Mix.Plugin.GitHub                    as MixGitHub
 
-type InviteMemberCmd = Record MemeberCmdFields
-
-type KickMemberCmd = Record MemeberCmdFields
-
-type MemeberCmdFields =
-  '[ "team"  >: Text
-   , "repos" >: [Int]
-   , "user"  >: Maybe Text
+type MemberCmdArg = Record
+  '[ "team"  >: TeamId
+   , "repos" >: [RepoId]
+   , "user"  >: Maybe UserId
    ]
 
-actForMember :: (User -> Repo -> Plant ()) -> Record MemeberCmdFields -> Team -> Plant ()
-actForMember act args team = case args ^. #repos of
-  [] -> forM_ (team ^. #repos) $ \repo -> forM_ member $ act' repo
-  _  -> forM_ repos            $ \repo -> forM_ member $ act' repo
-  where
-    act' repo user = tryAnyWithLogError $ act user repo
-    repos  = catMaybes $ flip lookupRepoByProblemId team <$> args ^. #repos
-    member = maybe (team ^. #member) (: []) $ flip lookupUser team =<< args ^. #user
+type MemberArg = Record
+  '[ "user" >: User
+   , "repo" >: Repo
+   ]
 
-inviteUserToRepo :: User -> Repo -> Plant ()
-inviteUserToRepo user target = do
-  github <- repoGithub target
+actForMember :: (MemberArg -> Plant ()) -> MemberCmdArg -> Plant ()
+actForMember act args = do
+  config <- asks $ view #config
+  mapM_ act $ do
+    team <- maybeToList $ findById (args ^. #team) (config ^. #teams)
+    repo <- filterByIdWithDefault (team ^. #repos) (args ^. #repos)
+    user <- filterByIdWithDefault (team ^. #member) (maybeToList $ args ^. #user)
+    pure $ #user @= user <: #repo @= repo <: nil
+
+inviteUserToRepo :: MemberArg -> Plant ()
+inviteUserToRepo args = do
+  github <- repoGithub $ args ^. #repo
   let (owner, repo) = splitRepoName github
   resp <- MixGitHub.fetch $ \auth -> GitHub.addCollaborator auth
     (mkName Proxy owner)
     (mkName Proxy repo)
-    (mkName Proxy $ user ^. #github)
+    (mkName Proxy $ args ^. #user ^. #github)
   case resp of
-    Left err -> logDebug (displayShow err) >> throwIO (InviteUserError err user target)
+    Left err -> logDebug (displayShow err) >> throwIO (failure err)
     Right _  -> logInfo $ display (success github)
   where
+    failure err = InviteUserError err (args ^. #user) (args ^. #repo)
     success githubPath = mconcat
       [ "Success: invite "
-      , user ^. #name, "(", user ^. #github, ")"
+      , args ^. #user ^. #name, "(", args ^. #user ^. #github, ")"
       , " to ", githubPath, "."
       ]
 
-kickUserFromRepo :: User -> Repo -> Plant ()
-kickUserFromRepo user target = do
-  github <- repoGithub target
+kickUserFromRepo :: MemberArg -> Plant ()
+kickUserFromRepo args = do
+  github <- repoGithub $ args ^. #repo
   let (owner, repo) = splitRepoName github
   resp <- MixGitHub.fetch $ \auth -> GitHub.removeCollaborator auth
     (mkName Proxy owner)
     (mkName Proxy repo)
-    (mkName Proxy $ user ^. #github)
+    (mkName Proxy $ args ^. #user ^. #github)
   case resp of
-    Left err -> logDebug (displayShow err) >> throwIO (KickUserError err user target)
+    Left err -> logDebug (displayShow err) >> throwIO (failure err)
     Right _  -> logInfo $ display (success github)
   where
+    failure err = KickUserError err (args ^. #user) (args ^. #repo)
     success githubPath = mconcat
       [ "Success: kick "
-      , user ^. #name, "(", user ^. #github, ")"
+      , args ^. #user ^. #name, "(", args ^. #user ^. #github, ")"
       , " from ", githubPath, "."
       ]

--- a/src/Git/Plantation/Cmd/Problem.hs
+++ b/src/Git/Plantation/Cmd/Problem.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE LambdaCase       #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeOperators    #-}
+
+module Git.Plantation.Cmd.Problem
+  ( ProblemCmdArg
+  , ProblemArg
+  , actForProblem
+  , showProblem
+  ) where
+
+import           RIO
+
+import           Data.Aeson.Text             (encodeToLazyText)
+import           Data.Extensible
+import           Git.Plantation.Cmd.Arg
+import           Git.Plantation.Data.Problem
+import           Git.Plantation.Env
+
+type ProblemCmdArg = Record
+  '[ "problems" >: [ProblemId]
+   ]
+
+type ProblemArg = Record
+  '[ "problem" >: Problem
+   ]
+
+actForProblem :: (ProblemArg -> Plant ()) -> ProblemCmdArg -> Plant ()
+actForProblem act args = do
+  problems <- findProblems $ args ^. #problems
+  mapM_ act $ hsequence $ #problem <@=> problems <: nil
+
+findProblems :: [ProblemId] -> Plant [Problem]
+findProblems []  = asks (view #problems . view #config)
+findProblems ids = fmap catMaybes . forM ids $ \idx ->
+  findByIdWith (view #problems) idx >>= \case
+    Nothing -> logError (display $ encodeToLazyText $ errMsg idx) >> pure Nothing
+    Just r  -> pure (Just r)
+
+showProblem :: ProblemArg -> Plant ()
+showProblem args = logInfo $ display $ mconcat
+  [ "- ", tshow $ args ^. #problem ^. #id, ": "
+  , args ^. #problem ^. #name
+  , "(⭐️ x", tshow $ args ^. #problem ^. #difficulty, ") at "
+  , "https://github.com/", args ^. #problem ^. #repo
+  ]

--- a/src/Git/Plantation/Cmd/Repo.hs
+++ b/src/Git/Plantation/Cmd/Repo.hs
@@ -87,8 +87,8 @@ findProblemWithThrow idx =
 
 createRepo :: NewRepoFlags -> RepoArg -> Plant ()
 createRepo flags args = do
-  logInfo $
-    display $ encodeToLazyText $ #message @= "create team repository" <: args
+  logInfo $ display $ encodeToLazyText $
+    #message @= ("create team repository" :: Text) <: args
   unless (flags ^. #skip_create_repo)   $ createRepoInGitHub args
   unless (flags ^. #skip_init_repo)     $ initRepoInGitHub args
   unless (flags ^. #skip_setup_webhook) $ setupWebhook args
@@ -194,8 +194,8 @@ pushForCI team problem = do
 
 deleteRepo :: RepoArg -> Plant ()
 deleteRepo args = do
-  logInfo $
-    display $ encodeToLazyText $ #message @= "delete team repository" <: args
+  logInfo $ display $ encodeToLazyText $
+    #message @= ("delete team repository" :: Text) <: args
   problem <- findProblemWithThrow (ProblemId $ args ^. #repo ^. #problem)
   deleteRepoInGithub (args ^. #repo)
   deleteProblemCI (args ^. #team) problem

--- a/src/Git/Plantation/Cmd/Repo.hs
+++ b/src/Git/Plantation/Cmd/Repo.hs
@@ -4,10 +4,24 @@
 {-# LANGUAGE OverloadedLabels     #-}
 {-# LANGUAGE TypeOperators        #-}
 
-module Git.Plantation.Cmd.Repo where
+module Git.Plantation.Cmd.Repo
+  ( RepoCmdArg
+  , RepoArg
+  , NewRepoFlags
+  , actForRepo
+  , createRepo
+  , createRepoInGitHub
+  , initRepoInGitHub
+  , setupWebhook
+  , initProblemCI
+  , resetRepo
+  , pushForCI
+  , deleteRepo
+  , splitRepoName
+  , repoGithub
+  ) where
 
 import           RIO
-import qualified RIO.List                        as L
 import qualified RIO.Map                         as Map
 import qualified RIO.Text                        as Text
 import qualified RIO.Vector                      as V
@@ -70,14 +84,6 @@ findProblemWithThrow idx =
   findByIdWith (view #problems) idx >>= \case
     Nothing  -> throwIO $ UndefinedProblem (coerce idx)
     Just p -> pure p
-
-actByProblemId :: (Team -> Problem -> Plant a) -> Team -> Int -> Plant ()
-actByProblemId act team pid = do
-  conf <- asks (view #config)
-  let problem = L.find (\p -> p ^. #id == pid) $ conf ^. #problems
-  case problem of
-    Nothing       -> logError $ "repo is not found by problem id: " <> display pid
-    Just problem' -> tryAnyWithLogError $ act team problem'
 
 createRepo :: NewRepoFlags -> RepoArg -> Plant ()
 createRepo flags args = do

--- a/src/Git/Plantation/Env.hs
+++ b/src/Git/Plantation/Env.hs
@@ -61,7 +61,8 @@ mkLogMessage' message =
 
 data GitPlantException
   = UndefinedTeamProblem Team Problem
-  | CreateRepoError GitHub.Error Team Problem
+  | UndefinedProblem Int
+  | CreateRepoError GitHub.Error Team Repo
   | DeleteRepoError GitHub.Error Repo
   | SetupWebhookError GitHub.Error Repo
   | InviteUserError GitHub.Error User Repo
@@ -77,6 +78,10 @@ instance Show GitPlantException where
       mkLogMessage'
         "undefined team repo"
         (#team @= team <: #problem @= problem <: nil)
+    UndefinedProblem idx ->
+      mkLogMessage'
+        "undefined problem"
+        (#id @= idx <: nil)
     CreateRepoError _err team problem ->
       mkLogMessage'
         "can't create repository"


### PR DESCRIPTION
gcloud コマンドみたいに、group を追加して

```
$ git-plantation-tool -c config.yaml --work .temp --verbose repo new --repos=3,4,5,6,7,8,9,10 zulu
```

みたいにした

* `git-plantation-tool (config|problem|member|repo) COMMAND` と指定する形式に変更
* 合わせてディレクトリ構造も刷新
* `problem` コマンドも追加
  * `show` : 問題の設定を出力するだけ


