### PR TITLE
GitHub Team に関するコマンドを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   * 合わせてディレクトリ構造も刷新
   * `problem` コマンドも追加
 * `mix-json-logger` パッケージを作成(#30)
+* GitHub Team に関するコマンドを追加(#31)
+  * `github` パッケージを更新
+  * `member invite/kick` に `--org` `--gh_team` オプションを追加して GitHub Team に招待/除外
+  * `org create_team` コマンドで GitHub Team を作成
+  * `repo add_gh_team` コマンドでリポジトリを GitHub Team に追加する
 
 ## v0.2.0
 

--- a/config/.git-plantation.yaml
+++ b/config/.git-plantation.yaml
@@ -38,6 +38,10 @@ problems:
 teams:
 - name: sample
   id: alpha
+  org: sample-hige
+  gh_teams:
+  - alpha-tutorial
+  - alpha
   member:
   - name: MATSUBARA Nobutada
     github: matsubara0507
@@ -46,11 +50,14 @@ teams:
     org: sample-hige
     problem: 1
     private: false
+    only: alpha-tutorial
   - name: git-challenge-is-order-an-adding
     org: sample-hige
     problem: 2
     private: false
+    only: alpha
   - name: git-challenge-minesweeper
     org: sample-hige
     problem: 3
     private: false
+    only: alpha

--- a/exec/tool/Options.hs
+++ b/exec/tool/Options.hs
@@ -59,6 +59,7 @@ repoCmdParser = fmap RepoCmd . variantFrom
    <: #init_ci       @= repoCmdArgParser `withInfo` "Init CI repository by team repository"
    <: #reset         @= repoCmdArgParser `withInfo` "Reset repository for team"
    <: #delete        @= repoCmdArgParser `withInfo` "Delete repository for team."
+   <: #add_gh_team   @= repoCmdArgParser `withInfo` "Add repository to GitHub team."
    <: nil
   where
     newRepoCmdParser = (,) <$> repoCmdArgParser <*> newRepoFlags

--- a/exec/tool/Options.hs
+++ b/exec/tool/Options.hs
@@ -83,9 +83,11 @@ memberCmdParser = fmap MemberCmd . variantFrom
 
 memberCmdArgParser :: Parser MemberCmdArg
 memberCmdArgParser = hsequence
-    $ #team  <@=> strArgument (metavar "TEXT" <> help "Sets team that want to controll.")
-   <: #repos <@=> option comma (long "repos" <> value [] <> metavar "ID" <> help "Sets reopsitory that want to controll by problem id.")
-   <: #user  <@=> option (Just <$> str) (long "user" <> value Nothing <> metavar "TEXT" <> help "Sets user that want to controll.")
+    $ #team    <@=> strArgument (metavar "TEXT" <> help "Sets team that want to controll.")
+   <: #repos   <@=> option comma (long "repos" <> value [] <> metavar "ID" <> help "Sets reopsitory that want to controll by problem id.")
+   <: #user    <@=> option (Just <$> str) (long "user" <> value Nothing <> metavar "TEXT" <> help "Sets user that want to controll.")
+   <: #org     <@=> switch (long "org" <> help "Manage member to GitHub Organization if true.")
+   <: #gh_team <@=> option (Just <$> str) (long "gh_team" <> value Nothing <> metavar "TEXT" <> help "Manage member to GitHub Org Team.")
    <: nil
 
 problemCmdParser :: Parser ProblemCmd

--- a/exec/tool/SubCmd.hs
+++ b/exec/tool/SubCmd.hs
@@ -10,6 +10,7 @@ module SubCmd
 
 import           SubCmd.Config      as X (ConfigCmd (..))
 import           SubCmd.Member      as X (MemberCmd (..))
+import           SubCmd.Org         as X (OrgCmd (..))
 import           SubCmd.Problem     as X (ProblemCmd (..))
 import           SubCmd.Repo        as X (RepoCmd (..))
 
@@ -22,6 +23,7 @@ type SubCmd = Variant
    , "repo"    >: RepoCmd
    , "member"  >: MemberCmd
    , "problem" >: ProblemCmd
+   , "org"     >: OrgCmd
    ]
 
 instance Run ("config" >: ConfigCmd) where
@@ -35,3 +37,6 @@ instance Run ("member" >: MemberCmd) where
 
 instance Run ("problem" >: ProblemCmd) where
   run' _ (ProblemCmd cmd) = run cmd
+
+instance Run ("org" >: OrgCmd) where
+  run' _ (OrgCmd cmd) = run cmd

--- a/exec/tool/SubCmd/Member.hs
+++ b/exec/tool/SubCmd/Member.hs
@@ -1,5 +1,7 @@
-{-# LANGUAGE DataKinds     #-}
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE MultiWayIf       #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeOperators    #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module SubCmd.Member
@@ -20,9 +22,13 @@ type CmdFields =
    ]
 
 instance Run ("invite" >: MemberCmdArg) where
-  run' _ args =
-    actForMember inviteUserToRepo args `catchAny` (logError . displayShow)
+  run' _ args = handleAny (logError . displayShow) $ if
+    | isJust (args ^. #gh_team) -> actForMemberWithGitHubTeam inviteUserToGitHubOrgTeam args
+    | args ^. #org              -> actForMemberWithOrg inviteUserToGitHubOrg args
+    | otherwise                 -> actForMember inviteUserToRepo args
 
 instance Run ("kick" >: MemberCmdArg) where
-  run' _ args =
-    actForMember kickUserFromRepo args `catchAny` (logError . displayShow)
+  run' _ args = handleAny (logError . displayShow) $ if
+    | isJust (args ^. #gh_team) -> actForMemberWithGitHubTeam kickUserFromGitHubOrgTeam args
+    | args ^. #org              -> actForMemberWithOrg kickUserFromGitHubOrg args
+    | otherwise                 -> actForMember kickUserFromRepo args

--- a/exec/tool/SubCmd/Org.hs
+++ b/exec/tool/SubCmd/Org.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE DataKinds     #-}
+{-# LANGUAGE TypeOperators #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module SubCmd.Org
+  ( OrgCmd (..)
+  ) where
+
+import           RIO
+
+import           Data.Extensible
+import           Git.Plantation.Cmd.Org
+import           Git.Plantation.Cmd.Run
+
+newtype OrgCmd = OrgCmd (Variant CmdField)
+
+type CmdField =
+  '[ "create_team" >: OrgCmdArg
+   ]
+
+instance Run ("create_team" >: OrgCmdArg) where
+  run' _ args =
+    actForGitHubTeam createGitHubTeam args `catchAny` (logError . displayShow)

--- a/exec/tool/SubCmd/Repo.hs
+++ b/exec/tool/SubCmd/Repo.hs
@@ -23,6 +23,7 @@ type CmdFields =
    , "init_ci"       >: RepoCmdArg
    , "reset"         >: RepoCmdArg
    , "delete"        >: RepoCmdArg
+   , "add_gh_team"   >: RepoCmdArg
    ]
 
 instance Run ("new" >: (RepoCmdArg, NewRepoFlags)) where
@@ -52,3 +53,7 @@ instance Run ("reset" >: RepoCmdArg) where
 instance Run ("delete" >: RepoCmdArg) where
   run' _ args =
     actForRepo deleteRepo args `catchAny` (logError . displayShow)
+
+instance Run ("add_gh_team" >: RepoCmdArg) where
+  run' _ args =
+    actForRepo addGitHubTeam args `catchAny` (logError . displayShow)

--- a/src/Git/Plantation/Cmd.hs
+++ b/src/Git/Plantation/Cmd.hs
@@ -13,6 +13,7 @@ import           RIO
 import           Data.Extensible
 import           Git.Plantation.Cmd.Arg     as X
 import           Git.Plantation.Cmd.Member  as X
+import           Git.Plantation.Cmd.Org     as X
 import           Git.Plantation.Cmd.Problem as X
 import           Git.Plantation.Cmd.Repo    as X
 import           Git.Plantation.Cmd.Run     as X

--- a/src/Git/Plantation/Cmd/Arg/Team.hs
+++ b/src/Git/Plantation/Cmd/Arg/Team.hs
@@ -44,3 +44,13 @@ instance IdArg UserId User where
       = #type @= "User"
      <: #id   @= coerce idx
      <: nil
+
+newtype GitHubTeamName = GitHubTeamName Text
+  deriving (IsString, ToJSON) via Text
+
+instance IdArg GitHubTeamName Text where
+  findById idx = L.find (== coerce idx)
+  toArgInfo idx
+      = #type @= "GitHub Team"
+      <: #id  @= coerce idx
+      <: nil

--- a/src/Git/Plantation/Cmd/Member.hs
+++ b/src/Git/Plantation/Cmd/Member.hs
@@ -9,30 +9,51 @@ module Git.Plantation.Cmd.Member
   , actForMember
   , inviteUserToRepo
   , kickUserFromRepo
+  , actForMemberWithOrg
+  , inviteUserToGitHubOrg
+  , kickUserFromGitHubOrg
+  , actForMemberWithGitHubTeam
+  , inviteUserToGitHubOrgTeam
+  , kickUserFromGitHubOrgTeam
   ) where
 
 import           RIO
 
 import           Data.Extensible
 import           Git.Plantation.Cmd.Arg
-import           Git.Plantation.Cmd.Repo              (repoGithub,
-                                                       splitRepoName)
+import           Git.Plantation.Cmd.Repo                (repoGithub,
+                                                         splitRepoName)
 import           Git.Plantation.Data
 import           Git.Plantation.Env
-import           GitHub.Data.Name                     (mkName)
-import qualified GitHub.Endpoints.Repos.Collaborators as GitHub
-import qualified Mix.Plugin.GitHub                    as MixGitHub
-import qualified Mix.Plugin.Logger.JSON               as Mix
+import           GitHub.Data.Name                       (mkName)
+import qualified GitHub.Endpoints.Organizations.Members as GitHub
+import qualified GitHub.Endpoints.Organizations.Teams   as GitHub
+import qualified GitHub.Endpoints.Repos.Collaborators   as GitHub
+import qualified Mix.Plugin.GitHub                      as MixGitHub
+import qualified Mix.Plugin.Logger.JSON                 as Mix
 
 type MemberCmdArg = Record
-  '[ "team"  >: TeamId
-   , "repos" >: [RepoId]
-   , "user"  >: Maybe UserId
+  '[ "team"    >: TeamId
+   , "repos"   >: [RepoId]
+   , "user"    >: Maybe UserId
+   , "org"     >: Bool
+   , "gh_team" >: Maybe Text
    ]
 
 type MemberArg = Record
   '[ "user" >: User
    , "repo" >: Repo
+   ]
+
+type MemberWithOrgArg = Record
+  '[ "user" >: User
+   , "org"  >: Text
+   ]
+
+type MemberWithGitHubTeamArg = Record
+  '[ "user"    >: User
+   , "org"  >: Text
+   , "gh_team" >: Text
    ]
 
 actForMember :: (MemberArg -> Plant ()) -> MemberCmdArg -> Plant ()
@@ -43,6 +64,27 @@ actForMember act args =
       member <- findMember (args ^. #user) team
       repos  <- findRepos (args ^. #repos) team
       mapM_ act $ hsequence $ #user <@=> member <: #repo <@=> repos <: nil
+
+actForMemberWithOrg ::
+  (MemberWithOrgArg -> Plant ()) -> MemberCmdArg -> Plant ()
+actForMemberWithOrg act args =
+  findByIdWith (view #teams) (args ^. #team) >>= \case
+    Nothing   -> Mix.logErrorR "not found by config" (toArgInfo $ args ^. #team)
+    Just team -> do
+      member <- findMember (args ^. #user) team
+      ghOrg  <- findGitHubOrg team
+      mapM_ act $ hsequence $ #user <@=> member <: #org <@=> ghOrg <: nil
+
+actForMemberWithGitHubTeam ::
+  (MemberWithGitHubTeamArg -> Plant ()) -> MemberCmdArg -> Plant ()
+actForMemberWithGitHubTeam act args =
+  findByIdWith (view #teams) (args ^. #team) >>= \case
+    Nothing   -> Mix.logErrorR "not found by config" (toArgInfo $ args ^. #team)
+    Just team -> do
+      member <- findMember (args ^. #user) team
+      ghOrg  <- findGitHubOrg team
+      ghTeam <- findGitHubTeam (args ^. #gh_team) team
+      mapM_ act $ hsequence $ #user <@=> member <: #org <@=> ghOrg <: #gh_team <@=> ghTeam <: nil
 
 findMember :: Maybe UserId -> Team -> Plant [User]
 findMember Nothing team = pure $ team ^. #member
@@ -58,6 +100,17 @@ findRepos ids team = fmap catMaybes . forM ids $ \idx ->
     Nothing -> Mix.logErrorR "not found by config" (toArgInfo idx) >> pure Nothing
     Just r  -> pure (Just r)
 
+findGitHubOrg :: Team -> Plant [Text]
+findGitHubOrg team = case team ^. #org of
+  Nothing  -> Mix.logErrorR "undefined GitHub org in config" nil >> pure []
+  Just org -> pure [org]
+
+findGitHubTeam :: Maybe Text -> Team -> Plant [Text]
+findGitHubTeam Nothing _ = pure []
+findGitHubTeam (Just name) team
+  | name `elem` team ^. #gh_teams = pure [name]
+  | otherwise = Mix.logErrorR "not found by config" (#gh_team @= name <: nil) >> pure []
+
 inviteUserToRepo :: MemberArg -> Plant ()
 inviteUserToRepo args = do
   github <- repoGithub $ args ^. #repo
@@ -70,7 +123,7 @@ inviteUserToRepo args = do
     Left err -> logDebug (displayShow err) >> throwIO (failure err)
     Right _  -> logInfo $ display (success github)
   where
-    failure err = InviteUserError err (args ^. #user) (args ^. #repo)
+    failure err = InviteUserError err (args ^. #user) (TargetRepo $ args ^. #repo)
     success githubPath = mconcat
       [ "Success: invite "
       , args ^. #user ^. #name, "(", args ^. #user ^. #github, ")"
@@ -89,9 +142,87 @@ kickUserFromRepo args = do
     Left err -> logDebug (displayShow err) >> throwIO (failure err)
     Right _  -> logInfo $ display (success github)
   where
-    failure err = KickUserError err (args ^. #user) (args ^. #repo)
+    failure err = KickUserError err (args ^. #user) (TargetRepo $ args ^. #repo)
     success githubPath = mconcat
       [ "Success: kick "
       , args ^. #user ^. #name, "(", args ^. #user ^. #github, ")"
       , " from ", githubPath, "."
+      ]
+
+inviteUserToGitHubOrg :: MemberWithOrgArg -> Plant ()
+inviteUserToGitHubOrg args = do
+  resp <- MixGitHub.fetch $ \auth -> GitHub.addOrUpdateMembership' auth
+    (mkName Proxy $ args ^. #org)
+    (mkName Proxy $ args ^. #user ^. #github)
+    False
+  case resp of
+    Left err -> logDebug (displayShow err) >> throwIO (failure err)
+    Right _  -> logInfo $ display success
+  where
+    failure err = InviteUserError err (args ^. #user) (TargetOrg $ args ^. #org)
+    success = mconcat
+      [ "Success: invite "
+      , args ^. #user ^. #name, "(", args ^. #user ^. #github, ")"
+      , " to ", args ^. #org, "."
+      ]
+
+kickUserFromGitHubOrg :: MemberWithOrgArg -> Plant ()
+kickUserFromGitHubOrg args = do
+  resp <- MixGitHub.fetch $ \auth -> GitHub.removeMembership' auth
+    (mkName Proxy $ args ^. #org)
+    (mkName Proxy $ args ^. #user ^. #github)
+  case resp of
+    Left err -> logDebug (displayShow err) >> throwIO (failure err)
+    Right _  -> logInfo $ display success
+  where
+    failure err = KickUserError err (args ^. #user) (TargetOrg $ args ^. #org)
+    success = mconcat
+      [ "Success: kick "
+      , args ^. #user ^. #name, "(", args ^. #user ^. #github, ")"
+      , " from ", args ^. #org, "."
+      ]
+
+inviteUserToGitHubOrgTeam :: MemberWithGitHubTeamArg -> Plant ()
+inviteUserToGitHubOrgTeam args = do
+  resp <- MixGitHub.fetch $ \auth -> GitHub.teamInfoByName' (Just auth)
+    (mkName Proxy $ args ^. #org)
+    (mkName Proxy $ args ^. #gh_team)
+  team <- case resp of
+    Left err   -> logDebug (displayShow err) >> throwIO (failure err)
+    Right team -> pure team
+  resp' <- MixGitHub.fetch $ \auth -> GitHub.addTeamMembershipFor' auth
+    (GitHub.teamId team)
+    (mkName Proxy $ args ^. #user ^. #github)
+    GitHub.RoleMember
+  case resp' of
+    Left err -> logDebug (displayShow err) >> throwIO (failure err)
+    Right _  -> logInfo $ display success
+  where
+    failure err = InviteUserError err (args ^. #user) (TargetTeam (args ^. #org) $ args ^. #gh_team)
+    success = mconcat
+      [ "Success: invite "
+      , args ^. #user ^. #name, "(", args ^. #user ^. #github, ")"
+      , " to ", args ^. #org, ":", args ^. #gh_team, "."
+      ]
+
+kickUserFromGitHubOrgTeam :: MemberWithGitHubTeamArg -> Plant ()
+kickUserFromGitHubOrgTeam args = do
+  resp <- MixGitHub.fetch $ \auth -> GitHub.teamInfoByName' (Just auth)
+    (mkName Proxy $ args ^. #org)
+    (mkName Proxy $ args ^. #gh_team)
+  team <- case resp of
+    Left err   -> logDebug (displayShow err) >> throwIO (failure err)
+    Right team -> pure team
+  resp' <- MixGitHub.fetch $ \auth -> GitHub.deleteTeamMembershipFor' auth
+    (GitHub.teamId team)
+    (mkName Proxy $ args ^. #user ^. #github)
+  case resp' of
+    Left err -> logDebug (displayShow err) >> throwIO (failure err)
+    Right _  -> logInfo $ display success
+  where
+    failure err = KickUserError err (args ^. #user) (TargetTeam (args ^. #org) $ args ^. #gh_team)
+    success = mconcat
+      [ "Success: kick "
+      , args ^. #user ^. #name, "(", args ^. #user ^. #github, ")"
+      , " from ", args ^. #org, ":", args ^. #gh_team, "."
       ]

--- a/src/Git/Plantation/Cmd/Org.hs
+++ b/src/Git/Plantation/Cmd/Org.hs
@@ -34,7 +34,7 @@ type GitHubTeamArg = Record
    ]
 
 actForGitHubTeam :: (GitHubTeamArg -> Plant ()) -> OrgCmdArg -> Plant ()
-actForGitHubTeam act args = do
+actForGitHubTeam act args =
   findByIdWith (view #teams) (args ^. #team) >>= \case
     Nothing   -> Mix.logErrorR "not found by config" (toArgInfo $ args ^. #team)
     Just team -> do

--- a/src/Git/Plantation/Data/Team.hs
+++ b/src/Git/Plantation/Data/Team.hs
@@ -8,7 +8,6 @@ module Git.Plantation.Data.Team where
 import           RIO
 import qualified RIO.List                    as L
 
-import           Data.Aeson                  (ToJSON (..))
 import           Data.Extensible
 import           Git.Plantation.Data.Problem
 import           Language.Elm

--- a/src/Git/Plantation/Data/Team.hs
+++ b/src/Git/Plantation/Data/Team.hs
@@ -8,15 +8,18 @@ module Git.Plantation.Data.Team where
 import           RIO
 import qualified RIO.List                    as L
 
+import           Data.Aeson                  (ToJSON (..))
 import           Data.Extensible
 import           Git.Plantation.Data.Problem
 import           Language.Elm
 
 type Team = Record
-  '[ "id"     >: Text
-   , "name"   >: Text
-   , "repos"  >: [Repo]
-   , "member" >: [User]
+  '[ "id"       >: Text
+   , "name"     >: Text
+   , "repos"    >: [Repo]
+   , "member"   >: [User]
+   , "org"      >: Maybe Text
+   , "gh_teams" >: [Text]
    ]
 
 instance ElmType Team where
@@ -36,10 +39,23 @@ type Repo = Record
    , "org"     >: Maybe Text
    , "problem" >: Int
    , "private" >: Bool
+   , "only"    >: Maybe Text -- GitHub Org Team
    ]
 
 instance ElmType Repo where
   toElmType = toElmRecordType "Repo"
+
+data MemberTarget
+  = TargetRepo Repo
+  | TargetOrg Text
+  | TargetTeam Text Text
+  deriving (Show, Eq)
+
+toMemberTargetRecord :: MemberTarget -> Record '[ "type" >: Text, "target" >: Maybe Text ]
+toMemberTargetRecord target = case target of
+  TargetRepo repo     -> #type @= "repo" <: #target @= repoGithubPath repo <: nil
+  TargetOrg org       -> #type @= "org"  <: #target @= Just org <: emptyRecord
+  TargetTeam org team -> #type @= "team" <: #target @= Just (org <> ":" <> team) <: nil
 
 lookupRepo :: Problem -> Team -> Maybe Repo
 lookupRepo problem = lookupRepoByProblemId (problem ^. #id)

--- a/src/Git/Plantation/Env.hs
+++ b/src/Git/Plantation/Env.hs
@@ -58,6 +58,7 @@ data GitPlantException
   | CreateRepoError GitHub.Error Team Repo
   | DeleteRepoError GitHub.Error Repo
   | SetupWebhookError GitHub.Error Repo
+  | AddRepoToGitHubTeamError GitHub.Error Text Text Repo
   | InviteUserError GitHub.Error User MemberTarget
   | KickUserError GitHub.Error User MemberTarget
   | CreateGitHubTeamError GitHub.Error Team Text
@@ -88,6 +89,10 @@ instance Show GitPlantException where
       mkLogMessage'
         "can't setup github webhook"
         (#repo @= repo <: nil)
+    AddRepoToGitHubTeamError _err org name repo ->
+      mkLogMessage'
+        "cant't add repository to GitHub team"
+        (#org @= org <: #gh_team @= name <: #repo @= repo <: nil)
     InviteUserError _err user target ->
       mkLogMessage'
         "can't invite user to repository"

--- a/src/Git/Plantation/Env.hs
+++ b/src/Git/Plantation/Env.hs
@@ -60,6 +60,7 @@ data GitPlantException
   | SetupWebhookError GitHub.Error Repo
   | InviteUserError GitHub.Error User MemberTarget
   | KickUserError GitHub.Error User MemberTarget
+  | CreateGitHubTeamError GitHub.Error Team Text
   | InvalidRepoConfig Repo
   deriving (Typeable)
 
@@ -95,6 +96,10 @@ instance Show GitPlantException where
       mkLogMessage'
         "can't kick user from repository"
         (#user @= user <: #target @= toMemberTargetRecord target <: nil)
+    CreateGitHubTeamError _err team name ->
+      mkLogMessage'
+        "can't create GitHub team in org"
+        (#team @= team <: #gh_team @= name <: nil)
     InvalidRepoConfig repo ->
       mkLogMessage'
         "invalid repo config"

--- a/src/Git/Plantation/Env.hs
+++ b/src/Git/Plantation/Env.hs
@@ -13,7 +13,7 @@ import qualified Data.Aeson.Text           as Json
 import           Data.Extensible
 import qualified Drone.Client              as Drone
 import           Git.Plantation.Config
-import           Git.Plantation.Data       (Problem, Repo, Team, User)
+import           Git.Plantation.Data
 import qualified Git.Plantation.Data.Slack as Slack
 import qualified GitHub.Auth               as GitHub
 import qualified GitHub.Data               as GitHub
@@ -58,8 +58,8 @@ data GitPlantException
   | CreateRepoError GitHub.Error Team Repo
   | DeleteRepoError GitHub.Error Repo
   | SetupWebhookError GitHub.Error Repo
-  | InviteUserError GitHub.Error User Repo
-  | KickUserError GitHub.Error User Repo
+  | InviteUserError GitHub.Error User MemberTarget
+  | KickUserError GitHub.Error User MemberTarget
   | InvalidRepoConfig Repo
   deriving (Typeable)
 
@@ -87,14 +87,14 @@ instance Show GitPlantException where
       mkLogMessage'
         "can't setup github webhook"
         (#repo @= repo <: nil)
-    InviteUserError _err user repo ->
+    InviteUserError _err user target ->
       mkLogMessage'
         "can't invite user to repository"
-        (#user @= user <: #repo @= repo <: nil)
-    KickUserError _err user repo ->
+        (#user @= user <: #target @= toMemberTargetRecord target <: nil)
+    KickUserError _err user target ->
       mkLogMessage'
         "can't kick user from repository"
-        (#user @= user <: #repo @= repo <: nil)
+        (#user @= user <: #target @= toMemberTargetRecord target <: nil)
     InvalidRepoConfig repo ->
       mkLogMessage'
         "invalid repo config"

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,7 +12,7 @@ extra-deps:
 - servant-github-webhook-0.4.1.0
 - shh-0.3.1.3
 - github: matsubara0507/github
-  commit: df371930d6369d1b2f37901619d8e8c56fb8fb60
+  commit: 8a4fb1d8bdbb0a6ac9e017401b503e4104afb29b
 - github: matsubara0507/drone-haskell
   commit: aa6f5152dd9ea72cb48a32bdc58c91de2bdc21a9
 - github: matsubara0507/elm-export


### PR DESCRIPTION
チームの管理を GitHub 組織アカウントの Team 機能を使って行えるように

* `member invite/kick` に `--org` `--gh_team` オプションを追加して GitHub Team に招待/除外
* `org create_team` コマンドで GitHub Team を作成
* `repo add_gh_team` コマンドでリポジトリを GitHub Team に追加する

また GitHub Team に関するエンドポイントが不足していたので `github` を更新した
