### PR TITLE
スコア取得が失敗したときに画面を真っ白にしない

### DIFF
--- a/elm-src/Main.elm
+++ b/elm-src/Main.elm
@@ -214,7 +214,7 @@ update msg model =
             ( { model | scores = Success scores }, Cmd.none )
 
         FetchScores (Err _) ->
-            ( { model | scores = Failure "Something went wrong.." }, Cmd.none )
+            ( model, Cmd.none )
 
 
 fetchScores : Cmd Msg


### PR DESCRIPTION
スコア取得が失敗した場合でも、過去の結果を出したままにします。