### PR TITLE
スコアボードのページをリファクタリング

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM codesimple/elm:0.19 as build-elm
 WORKDIR /work
 COPY . /work
 RUN elm make elm-src/Main.elm --output=static/main.js
-RUN elm make elm-src/Pages/Graph.elm --output=static/graph.js
 
 FROM matsubara0507/ubuntu-for-haskell:git
 ARG local_bin_path

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM codesimple/elm:0.19 as build-elm
 WORKDIR /work
 COPY . /work
-RUN elm make elm-src/Pages/Board.elm --output=static/main.js
+RUN elm make elm-src/Main.elm --output=static/main.js
 RUN elm make elm-src/Pages/Graph.elm --output=static/graph.js
 
 FROM matsubara0507/ubuntu-for-haskell:git

--- a/elm-src/Main.elm
+++ b/elm-src/Main.elm
@@ -1,0 +1,150 @@
+module Main exposing (main)
+
+import Browser as Browser
+import Browser.Navigation as Nav
+import Generated.API as API exposing (..)
+import Html exposing (..)
+import Html.Attributes exposing (checked, class, href, id, style, target, type_)
+import Html.Events exposing (onCheck, onClick)
+import Http
+import Pages.Board as Board
+import Score exposing (Score)
+import Time exposing (Posix)
+import Url
+
+
+main =
+    Browser.application
+        { init = init
+        , view = view
+        , update = update
+        , subscriptions = subscriptions
+        , onUrlRequest = LinkClicked
+        , onUrlChange = UrlChanged
+        }
+
+
+type alias Model =
+    { key : Nav.Key
+    , page : Page
+    , config : API.ScoreBoardConfig
+    , problems : List API.Problem
+    , scores : List Score
+    , reload : Bool
+    }
+
+
+type Page
+    = Home -- Board
+
+
+type Msg
+    = LinkClicked Browser.UrlRequest
+    | UrlChanged Url.Url
+    | CheckReload Bool
+    | Reload
+    | Tick Posix
+    | FetchScores (Result Http.Error (List API.Score))
+
+
+init : { config : API.Config } -> Url.Url -> Nav.Key -> ( Model, Cmd Msg )
+init { config } url key =
+    stepUrl url
+        { key = key
+        , page = Home
+        , config = config.scoreboard
+        , reload = True
+        , problems = config.problems
+        , scores = Score.build config []
+        }
+
+
+stepUrl : Url.Url -> Model -> ( Model, Cmd Msg )
+stepUrl _ model =
+    ( model, Cmd.batch [ API.getApiScores FetchScores ] )
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        LinkClicked (Browser.Internal url) ->
+            ( model, Nav.pushUrl model.key (Url.toString url) )
+
+        LinkClicked (Browser.External href) ->
+            ( model, Nav.load href )
+
+        UrlChanged url ->
+            stepUrl url model
+
+        CheckReload reload ->
+            ( { model | reload = reload }, Cmd.none )
+
+        Reload ->
+            ( model, API.getApiScores FetchScores )
+
+        Tick _ ->
+            ( model
+            , if model.reload then
+                API.getApiScores FetchScores
+
+              else
+                Cmd.none
+            )
+
+        FetchScores (Ok resp) ->
+            ( { model | scores = Score.updateBy resp model.scores }, Cmd.none )
+
+        FetchScores (Err _) ->
+            ( model, Cmd.none )
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Time.every model.config.interval Tick
+
+
+view : Model -> Browser.Document Msg
+view model =
+    { title = "Git Challenge ScoreBoard"
+    , body = viewBody model
+    }
+
+
+viewBody : Model -> List (Html Msg)
+viewBody model =
+    [ div [ class "my-3 mx-auto col-10" ]
+        [ div []
+            [ h2
+                [ class "f1-light float-left link-gray-dark"
+                , onClick Reload
+                ]
+                [ text "Git Challenge ScoreBoard" ]
+            , div [ class "float-right" ] [ viewCheckReload model ]
+            ]
+        , viewPage model
+        ]
+    ]
+
+
+viewCheckReload : Model -> Html Msg
+viewCheckReload model =
+    form []
+        [ div [ class "form-checkbox" ]
+            [ label []
+                [ input
+                    [ type_ "checkbox"
+                    , checked model.reload
+                    , onCheck CheckReload
+                    ]
+                    []
+                , text "Auto Reload"
+                ]
+            ]
+        ]
+
+
+viewPage : Model -> Html Msg
+viewPage model =
+    case model.page of
+        Home ->
+            Board.view model

--- a/elm-src/Score.elm
+++ b/elm-src/Score.elm
@@ -1,0 +1,128 @@
+module Score exposing (Score, State(..), Status, Team, build, updateBy)
+
+import Generated.API as API
+import List.Extra as List
+
+
+type alias Score =
+    { team : Team
+    , point : Int
+    , stats : List Status
+    }
+
+
+type alias Team =
+    { id : String
+    , name : String
+    , member : List API.User
+    }
+
+
+type alias Status =
+    { problemId : Int
+    , problemName : String
+    , difficulty : Int
+    , url : String
+    , state : State
+    , correctTime : Int -- unixtime
+    }
+
+
+type State
+    = None
+    | Pending
+    | Incorrect
+    | Correct
+
+
+build : { a | problems : List API.Problem, teams : List API.Team } -> List API.Score -> List Score
+build { problems, teams } scores =
+    List.map (buildEmptyScore problems) teams
+        |> updateBy scores
+
+
+buildEmptyScore : List API.Problem -> API.Team -> Score
+buildEmptyScore problems team =
+    { team = { id = team.id, name = team.name, member = team.member }
+    , point = 0
+    , stats = List.map buildEmptyStatus problems
+    }
+
+
+buildEmptyStatus : API.Problem -> Status
+buildEmptyStatus problem =
+    { problemId = problem.id
+    , problemName = problem.name
+    , difficulty = problem.difficulty
+    , url = ""
+    , state = None
+    , correctTime = 0
+    }
+
+
+updateBy : List API.Score -> List Score -> List Score
+updateBy respScores scores =
+    for scores
+        (\score ->
+            case List.find (\s -> s.team == score.team.id) respScores of
+                Nothing ->
+                    score
+
+                Just resp ->
+                    updateScoreBy resp score
+        )
+
+
+updateScoreBy : API.Score -> Score -> Score
+updateScoreBy respScore score =
+    { score
+        | point = respScore.point
+        , stats = List.map (updateStatsBy respScore) score.stats
+    }
+
+
+updateStatsBy : API.Score -> Status -> Status
+updateStatsBy respScore status =
+    let
+        url =
+            respScore.links
+                |> List.find (\l -> l.problem_id == status.problemId)
+                |> Maybe.map .url
+                |> Maybe.withDefault status.url
+
+        respStatus =
+            List.find (\s -> s.problem_id == status.problemId) respScore.stats
+
+        state =
+            respStatus
+                |> Maybe.map toState
+                |> Maybe.withDefault status.state
+
+        correctTime =
+            respStatus
+                |> Maybe.andThen .corrected_at
+                |> Maybe.withDefault status.correctTime
+    in
+    { status | url = url, state = state, correctTime = correctTime }
+
+
+toState : API.Status -> State
+toState status =
+    case ( status.correct, status.pending ) of
+        ( _, True ) ->
+            Pending
+
+        ( False, _ ) ->
+            Incorrect
+
+        ( True, _ ) ->
+            Correct
+
+
+
+-- Util
+
+
+for : List a -> (a -> b) -> List b
+for xs f =
+    List.map f xs

--- a/elm.json
+++ b/elm.json
@@ -20,7 +20,6 @@
             "elm-community/list-extra": "8.2.2",
             "justinmimbs/time-extra": "1.1.0",
             "justinmimbs/timezone-data": "2.1.4",
-            "krisajenkins/remotedata": "6.0.1",
             "myrho/elm-round": "1.0.4",
             "ryannhg/date-format": "2.3.0",
             "tesk9/palette": "2.0.0"

--- a/src/Git/Plantation/API.hs
+++ b/src/Git/Plantation/API.hs
@@ -19,21 +19,25 @@ import qualified Text.Blaze.Html5            as H
 import qualified Text.Blaze.Html5.Attributes as H
 
 type API
-      = Get '[HTML] H.Html
-   :<|> "graph"  :> Get '[HTML] H.Html
-   :<|> "static" :> Raw
+      = "static" :> Raw
    :<|> "hook"   :> WebhookAPI
    :<|> "api"    :> CRUD
+   :<|> Index
+
+type Index
+      = Get '[HTML] H.Html
+   :<|> "graph" :> Get '[HTML] H.Html
 
 api :: Proxy API
 api = Proxy
 
 server :: ServerT API Plant
-server = indexHtml
-    :<|> indexHtml
-    :<|> serveDirectoryFileServer "static"
+server = serveDirectoryFileServer "static"
     :<|> webhook
     :<|> crud
+    :<|> index
+    where
+      index = indexHtml :<|> indexHtml
 
 indexHtml :: Plant H.Html
 indexHtml = do

--- a/src/Git/Plantation/API.hs
+++ b/src/Git/Plantation/API.hs
@@ -30,7 +30,7 @@ api = Proxy
 
 server :: ServerT API Plant
 server = indexHtml
-    :<|> graphHtml
+    :<|> indexHtml
     :<|> serveDirectoryFileServer "static"
     :<|> webhook
     :<|> crud
@@ -46,19 +46,6 @@ indexHtml = do
     H.script ! H.type_ "application/json" ! H.id "config" $
       H.preEscapedLazyText (Json.encodeToLazyText config)
     H.script ! H.src "static/main.js" $ H.text ""
-    H.script ! H.src "static/index.js" $ H.text ""
-
-graphHtml :: Plant H.Html
-graphHtml = do
-  config <- asks (view #config)
-  pure $ H.docTypeHtml $ do
-    H.head $ do
-      stylesheet "https://cdnjs.cloudflare.com/ajax/libs/Primer/10.8.1/build.css"
-      stylesheet "https://use.fontawesome.com/releases/v5.2.0/css/all.css"
-    H.div ! H.id "main" $ H.text ""
-    H.script ! H.type_ "application/json" ! H.id "config" $
-      H.preEscapedLazyText (Json.encodeToLazyText config)
-    H.script ! H.src "static/graph.js" $ H.text ""
     H.script ! H.src "static/index.js" $ H.text ""
 
 stylesheet :: H.AttributeValue -> H.Html


### PR DESCRIPTION
現状、スコアボードとグラフが SPA x2 って状態なので良い感じに合わせれないか試す

- [x] Score 型を作って共用する
   - 現状 `API` のデータ型をそのまんま使って view の中で `List.find` とかしてる
   - なので view に都合の良いデータ型へ最初に変換しそれを使って view する
- [x] 一つの SPA にする
   - model に `Page` 追加して自分で Routing する
   - 参考 https://github.com/elm/package.elm-lang.org
   - こうすると auto reload の部分とか共通化できる気がする