### PR TITLE
依存パッケージを更新 with LTS 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
 - スコアボードに個人のページを追加(#56)
 - GitHub Actions の設定を追加(#57)
 - Elm のバージョンを 0.19.1 に変更(#57)
+- LTS を 15.5 に更新(#58)
+  - GHC を 8.8.3 に更新
+  - extensible を 0.8 に更新
+  - github を 0.25 に更新
+  - drone を 1.1.0 に更新
 
 ## Unreleased changes
 

--- a/elm-src/Generated/API.elm
+++ b/elm-src/Generated/API.elm
@@ -1,4 +1,4 @@
-module Generated.API exposing (Config, Link, Problem, Repo, Score, ScoreBoardConfig, Status, Team, User, getApiProblems, getApiScores, getApiScoresByTeam, getApiScoresByTeamByPlayer, getApiTeams, jsonDecConfig, jsonDecLink, jsonDecProblem, jsonDecRepo, jsonDecScore, jsonDecScoreBoardConfig, jsonDecStatus, jsonDecTeam, jsonDecUser, jsonEncConfig, jsonEncLink, jsonEncProblem, jsonEncRepo, jsonEncScore, jsonEncScoreBoardConfig, jsonEncStatus, jsonEncTeam, jsonEncUser, maybeBoolToIntStr)
+module Generated.API exposing (Config, Link, Problem, Repo, Score, ScoreBoardConfig, Status, Team, User, getApiProblems, getApiScores, getApiScoresByTeam, getApiScoresByTeamByPlayer, getApiTeams, jsonDecConfig, jsonDecLink, jsonDecProblem, jsonDecRepo, jsonDecScore, jsonDecScoreBoardConfig, jsonDecStatus, jsonDecTeam, jsonDecUser, jsonEncConfig, jsonEncLink, jsonEncProblem, jsonEncRepo, jsonEncScore, jsonEncScoreBoardConfig, jsonEncStatus, jsonEncTeam, jsonEncUser)
 
 -- The following module comes from bartavelle/json-helpers
 
@@ -10,19 +10,6 @@ import Json.Helpers exposing (..)
 import Set
 import String
 import Url.Builder
-
-
-maybeBoolToIntStr : Maybe Bool -> String
-maybeBoolToIntStr mx =
-    case mx of
-        Nothing ->
-            ""
-
-        Just True ->
-            "1"
-
-        Just False ->
-            "0"
 
 
 type alias Team =

--- a/src/Git/Plantation/API.hs
+++ b/src/Git/Plantation/API.hs
@@ -13,7 +13,6 @@ import           Git.Plantation.API.Webhook  (WebhookAPI, webhook)
 import           Git.Plantation.Env          (Plant)
 import           Servant
 import           Servant.HTML.Blaze
-import           Servant.Server.StaticFiles  (serveDirectoryFileServer)
 import           Text.Blaze.Html5            ((!))
 import qualified Text.Blaze.Html5            as H
 import qualified Text.Blaze.Html5.Attributes as H

--- a/src/Git/Plantation/Cmd/Member.hs
+++ b/src/Git/Plantation/Cmd/Member.hs
@@ -115,7 +115,7 @@ inviteUserToRepo :: MemberArg -> Plant ()
 inviteUserToRepo args = do
   github <- repoGithub $ args ^. #repo
   let (owner, repo) = splitRepoName github
-  resp <- MixGitHub.fetch $ \auth -> GitHub.addCollaborator auth
+  resp <- MixGitHub.fetch $ GitHub.addCollaboratorR
     (mkName Proxy owner)
     (mkName Proxy repo)
     (mkName Proxy $ args ^. #user ^. #github)
@@ -134,7 +134,7 @@ kickUserFromRepo :: MemberArg -> Plant ()
 kickUserFromRepo args = do
   github <- repoGithub $ args ^. #repo
   let (owner, repo) = splitRepoName github
-  resp <- MixGitHub.fetch $ \auth -> GitHub.removeCollaborator auth
+  resp <- MixGitHub.fetch $ GitHub.removeCollaboratorR
     (mkName Proxy owner)
     (mkName Proxy repo)
     (mkName Proxy $ args ^. #user ^. #github)
@@ -151,7 +151,7 @@ kickUserFromRepo args = do
 
 inviteUserToGitHubOrg :: MemberWithOrgArg -> Plant ()
 inviteUserToGitHubOrg args = do
-  resp <- MixGitHub.fetch $ \auth -> GitHub.addOrUpdateMembership' auth
+  resp <- MixGitHub.fetch $ GitHub.addOrUpdateMembershipR
     (mkName Proxy $ args ^. #org)
     (mkName Proxy $ args ^. #user ^. #github)
     False
@@ -168,7 +168,7 @@ inviteUserToGitHubOrg args = do
 
 kickUserFromGitHubOrg :: MemberWithOrgArg -> Plant ()
 kickUserFromGitHubOrg args = do
-  resp <- MixGitHub.fetch $ \auth -> GitHub.removeMembership' auth
+  resp <- MixGitHub.fetch $ GitHub.removeMembershipR
     (mkName Proxy $ args ^. #org)
     (mkName Proxy $ args ^. #user ^. #github)
   case resp of
@@ -184,13 +184,13 @@ kickUserFromGitHubOrg args = do
 
 inviteUserToGitHubOrgTeam :: MemberWithGitHubTeamArg -> Plant ()
 inviteUserToGitHubOrgTeam args = do
-  resp <- MixGitHub.fetch $ \auth -> GitHub.teamInfoByName' (Just auth)
+  resp <- MixGitHub.fetch $ GitHub.teamInfoByNameR
     (mkName Proxy $ args ^. #org)
     (mkName Proxy $ args ^. #gh_team)
   team <- case resp of
     Left err   -> logDebug (displayShow err) >> throwIO (failure err)
     Right team -> pure team
-  resp' <- MixGitHub.fetch $ \auth -> GitHub.addTeamMembershipFor' auth
+  resp' <- MixGitHub.fetch $ GitHub.addTeamMembershipForR
     (GitHub.teamId team)
     (mkName Proxy $ args ^. #user ^. #github)
     GitHub.RoleMember
@@ -207,13 +207,13 @@ inviteUserToGitHubOrgTeam args = do
 
 kickUserFromGitHubOrgTeam :: MemberWithGitHubTeamArg -> Plant ()
 kickUserFromGitHubOrgTeam args = do
-  resp <- MixGitHub.fetch $ \auth -> GitHub.teamInfoByName' (Just auth)
+  resp <- MixGitHub.fetch $ GitHub.teamInfoByNameR
     (mkName Proxy $ args ^. #org)
     (mkName Proxy $ args ^. #gh_team)
   team <- case resp of
     Left err   -> logDebug (displayShow err) >> throwIO (failure err)
     Right team -> pure team
-  resp' <- MixGitHub.fetch $ \auth -> GitHub.deleteTeamMembershipFor' auth
+  resp' <- MixGitHub.fetch $ GitHub.deleteTeamMembershipForR
     (GitHub.teamId team)
     (mkName Proxy $ args ^. #user ^. #github)
   case resp' of

--- a/src/Git/Plantation/Cmd/Org.hs
+++ b/src/Git/Plantation/Cmd/Org.hs
@@ -54,7 +54,7 @@ findGitHubTeams ids team = case (team ^. #org, ids) of
 
 createGitHubTeam :: GitHubTeamArg -> Plant ()
 createGitHubTeam args = do
-  resp <- MixGitHub.fetch $ \auth -> GitHub.createTeamFor' auth
+  resp <- MixGitHub.fetch $ GitHub.createTeamForR
     (mkName Proxy $ args ^. #org)
     (GitHub.CreateTeam (mkName Proxy $ args ^. #gh_team) Nothing mempty GitHub.PermissionPush)
   case resp of

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,23 +1,23 @@
-resolver: lts-14.6
+resolver: lts-15.5
 packages:
 - .
 extra-deps:
-- extensible-0.6.1
+- extensible-0.8
 - membership-0
-- binary-instances-1
-- servant-github-webhook-0.4.1.0
-- github: matsubara0507/drone-haskell
-  commit: d71e7473508a88922575ab95330b1e94d2114f9c
+- binary-instances-1.0.0.1
+- servant-github-webhook-0.4.2.0
+- github-webhooks-0.12.0
+- drone-1.1.0
 - github: matsubara0507/github
-  commit: 0e53921d2433c3e86b7231e6be7d234ae75c095f
+  commit: 8224d498d289c40d3c6d0232ac571a82f8787972
 - github: matsubara0507/elmap.hs
-  commit: a1539c3be6e8b5757a2a10a55e7c1b19c1fc76fd
+  commit: 9c9479d3ead6032a0309b5f80f42e94df85da375
   subdirs:
   - elmap
   - servant-elmap
   - extensible-elmap
 - github: matsubara0507/mix.hs
-  commit: f4cad8e116093169c8849a9ae9acefb93c3eefc5
+  commit: a0b2b9394c340186c9a8a63808f0db1752ada4ae
   subdirs:
   - mix
   - mix-json-logger

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: extensible-0.6.1@sha256:d73a5dc13bd00f44ace729f83ce868e81a45ea31c7453a6f8a4a9b5b0591d600,2860
+    hackage: extensible-0.8@sha256:45ca089909ae434329e4d05dc557be94ff04f24c43ff9b915bd90c0599c83211,2911
     pantry-tree:
-      size: 2354
-      sha256: 9fadd24af89df601f19d57893b513d1742a1942670d6d2e73e79fb4b7aabce65
+      size: 2097
+      sha256: d602c9d623afd9186a4d55898ef97f0dfb7f81ffbd5bae86e2238b3694d702fb
   original:
-    hackage: extensible-0.6.1
+    hackage: extensible-0.8
 - completed:
     hackage: membership-0@sha256:3a11d8fd53cb1a76bb9273e6c929bbf9d649f109714bf487abb3143be04ddc81,995
     pantry-tree:
@@ -19,178 +19,178 @@ packages:
   original:
     hackage: membership-0
 - completed:
-    hackage: binary-instances-1@sha256:cdef50410f2797de38f021d328d38c32b2f4abeaab86bfaf78e0657150863090,2613
+    hackage: binary-instances-1.0.0.1@sha256:70c5759ab4f09cf661f68b72b3543872bc32b61095159d2bfcda8d71dce29b7e,2637
     pantry-tree:
       size: 1035
-      sha256: b58b9e7a482f158b33d87d807cd91bf99e6cd998593f4d9b11d96e978559a690
+      sha256: b0d454f73c456c07f02e40002444922ec23278955a222466a8063800aa949c6d
   original:
-    hackage: binary-instances-1
+    hackage: binary-instances-1.0.0.1
 - completed:
-    hackage: servant-github-webhook-0.4.1.0@sha256:6ac456ccc6a2a96b30a7b80cd91b121f1b7e9bd33635641a6afbd6137700a753,2754
+    hackage: servant-github-webhook-0.4.2.0@sha256:fbc981cb5479058ef864c1955190944f7d417d563884560fc3b1911447730ffa,2739
     pantry-tree:
       size: 576
-      sha256: f00112fb96ffe1caa7076a466868af0b47eed0ffea92792b3cde5a5e369a7005
+      sha256: 1e27db682388a10c56a58b14b347b5157e6a215164c8102928332e9a62db2b41
   original:
-    hackage: servant-github-webhook-0.4.1.0
+    hackage: servant-github-webhook-0.4.2.0
 - completed:
-    size: 11811
-    url: https://github.com/matsubara0507/drone-haskell/archive/d71e7473508a88922575ab95330b1e94d2114f9c.tar.gz
-    cabal-file:
-      size: 2607
-      sha256: 5c70500c3da54351d6a2d3fcedddc11bd71bffb4251f277b02808a3ac65320e0
-    name: drone
-    version: 1.0.1
-    sha256: 7810e98a024de3b0df8c6849d3506331d603d857c5c221a80af502bf570f8a5a
+    hackage: github-webhooks-0.12.0@sha256:38dfaca212c2b75d6a10e270909d42c820f7968cb5937bebc76af0e72c66b058,3911
     pantry-tree:
-      size: 2673
-      sha256: c2e3460ade37eb75150ce34d938e4d412c01e08e6e0cb16fdefd9015885bed9a
+      size: 3448
+      sha256: 6c0fe2f434451ffb8fe4d4652c230cfe57f9c8a647ae66ab420afc7c6de06598
   original:
-    url: https://github.com/matsubara0507/drone-haskell/archive/d71e7473508a88922575ab95330b1e94d2114f9c.tar.gz
+    hackage: github-webhooks-0.12.0
 - completed:
-    size: 93288
-    url: https://github.com/matsubara0507/github/archive/0e53921d2433c3e86b7231e6be7d234ae75c095f.tar.gz
+    hackage: drone-1.1.0@sha256:ec948081678076e905b2a983c7f4d46b60d2ebeae608fe6f7e5c3917dd389d35,2603
+    pantry-tree:
+      size: 2422
+      sha256: b2a66629477c6449cabab44caa67dbac988fb1c251d70387d4d382f55c5d4d8b
+  original:
+    hackage: drone-1.1.0
+- completed:
+    size: 87815
+    url: https://github.com/matsubara0507/github/archive/8224d498d289c40d3c6d0232ac571a82f8787972.tar.gz
     cabal-file:
-      size: 6909
-      sha256: 13f09e904248a40dd173c08f2859d0dfda178a7c27f88df20b70a0d5a7614757
+      size: 7091
+      sha256: dd202179060eb0160e048366a8add67125493a5d54abe53d673175312f4dddf1
     name: github
-    version: '0.22'
-    sha256: 7ec8fd5d7053204563d8f28ae4910eb8d40fa6f76b9d67b208905dd28ca9e71f
+    version: '0.24'
+    sha256: 3dfa0789a1199900203b45901930c21c3646fd78d1e94490dd1444531c06015f
     pantry-tree:
-      size: 15814
-      sha256: 3795c9a117b2db777a345c8b29ce4335cd7d35774cc584ad97171be349b59908
+      size: 16236
+      sha256: 266e2e2ecda5e39c95d8d89a52a52dda2bbc87e0986069fcf9577bed7bf72c31
   original:
-    url: https://github.com/matsubara0507/github/archive/0e53921d2433c3e86b7231e6be7d234ae75c095f.tar.gz
+    url: https://github.com/matsubara0507/github/archive/8224d498d289c40d3c6d0232ac571a82f8787972.tar.gz
 - completed:
-    size: 36888
+    size: 19650
     subdir: elmap
-    url: https://github.com/matsubara0507/elmap.hs/archive/a1539c3be6e8b5757a2a10a55e7c1b19c1fc76fd.tar.gz
+    url: https://github.com/matsubara0507/elmap.hs/archive/9c9479d3ead6032a0309b5f80f42e94df85da375.tar.gz
     cabal-file:
       size: 1788
       sha256: e914e320116772e38d19fc5fbbe0db6827fd23f82be6a82c4d1e9691863c5861
     name: elmap
     version: 0.1.0.0
-    sha256: cfad46e892a213329434d0df6935f9fe08e5ea30ba9d880bda36bac662f34806
+    sha256: 2007d3eaf2df739e27533469921a6bc4ece0fc5d7efdc88ff3afa354a44fbafa
     pantry-tree:
       size: 476
       sha256: a59c6ff50ae3f2cecdf16e12fe38f75e00e266a9ded559ef8ca876d05d764abe
   original:
     subdir: elmap
-    url: https://github.com/matsubara0507/elmap.hs/archive/a1539c3be6e8b5757a2a10a55e7c1b19c1fc76fd.tar.gz
+    url: https://github.com/matsubara0507/elmap.hs/archive/9c9479d3ead6032a0309b5f80f42e94df85da375.tar.gz
 - completed:
-    size: 36888
+    size: 19650
     subdir: servant-elmap
-    url: https://github.com/matsubara0507/elmap.hs/archive/a1539c3be6e8b5757a2a10a55e7c1b19c1fc76fd.tar.gz
+    url: https://github.com/matsubara0507/elmap.hs/archive/9c9479d3ead6032a0309b5f80f42e94df85da375.tar.gz
     cabal-file:
       size: 2194
       sha256: 60205e8a33494474cbc09a5481f83b2cbc4fb41a106a1ed23c74d0eec5661469
     name: servant-elmap
     version: 0.1.0.0
-    sha256: cfad46e892a213329434d0df6935f9fe08e5ea30ba9d880bda36bac662f34806
+    sha256: 2007d3eaf2df739e27533469921a6bc4ece0fc5d7efdc88ff3afa354a44fbafa
     pantry-tree:
-      size: 558
-      sha256: 6781fe28f19d1fcebd630e589b68d7d52b10b2436a279f17878ad01fd4b39678
+      size: 614
+      sha256: d423d9bcb549db5c1dfa93276c57bab26f85db79a77da97cea17c1ae97ea78ef
   original:
     subdir: servant-elmap
-    url: https://github.com/matsubara0507/elmap.hs/archive/a1539c3be6e8b5757a2a10a55e7c1b19c1fc76fd.tar.gz
+    url: https://github.com/matsubara0507/elmap.hs/archive/9c9479d3ead6032a0309b5f80f42e94df85da375.tar.gz
 - completed:
-    size: 36888
+    size: 19650
     subdir: extensible-elmap
-    url: https://github.com/matsubara0507/elmap.hs/archive/a1539c3be6e8b5757a2a10a55e7c1b19c1fc76fd.tar.gz
+    url: https://github.com/matsubara0507/elmap.hs/archive/9c9479d3ead6032a0309b5f80f42e94df85da375.tar.gz
     cabal-file:
       size: 1744
       sha256: 2cc0c5e1d41ddede33c6b68e9f7a0ccfacbf10c05c449d551b34bb6df1d3cfd2
     name: extensible-elmap
     version: 0.1.0.0
-    sha256: cfad46e892a213329434d0df6935f9fe08e5ea30ba9d880bda36bac662f34806
+    sha256: 2007d3eaf2df739e27533469921a6bc4ece0fc5d7efdc88ff3afa354a44fbafa
     pantry-tree:
       size: 439
-      sha256: 60f665a4bca0c0676e6456f6fe32204cb0f28873c62fc75dc374d6e82aa3efa6
+      sha256: 545989814406ca47317920086e82cf54299eff0543516ed854eb99ed0cadf4d4
   original:
     subdir: extensible-elmap
-    url: https://github.com/matsubara0507/elmap.hs/archive/a1539c3be6e8b5757a2a10a55e7c1b19c1fc76fd.tar.gz
+    url: https://github.com/matsubara0507/elmap.hs/archive/9c9479d3ead6032a0309b5f80f42e94df85da375.tar.gz
 - completed:
-    size: 8272
+    size: 8476
     subdir: mix
-    url: https://github.com/matsubara0507/mix.hs/archive/f4cad8e116093169c8849a9ae9acefb93c3eefc5.tar.gz
+    url: https://github.com/matsubara0507/mix.hs/archive/a0b2b9394c340186c9a8a63808f0db1752ada4ae.tar.gz
     cabal-file:
       size: 1110
       sha256: 946df4a87070784d7ea659f6a3ad2f346f8cf31fea1135fc342feb5a303fa147
     name: mix
     version: 0.1.1
-    sha256: 8daa72bb527fa53dd5f64eb21f0213a665db671351456468c8dd0da1e129945b
+    sha256: f879d5d044d8531814a8cd5bbda08ab2a513eb04a150e44526ea0f49961e38a1
     pantry-tree:
       size: 598
       sha256: 689bed307dc233a6c50e01f00295a079dc40a4291700646f3ca423d714ba35fc
   original:
     subdir: mix
-    url: https://github.com/matsubara0507/mix.hs/archive/f4cad8e116093169c8849a9ae9acefb93c3eefc5.tar.gz
+    url: https://github.com/matsubara0507/mix.hs/archive/a0b2b9394c340186c9a8a63808f0db1752ada4ae.tar.gz
 - completed:
-    size: 8272
+    size: 8476
     subdir: mix-json-logger
-    url: https://github.com/matsubara0507/mix.hs/archive/f4cad8e116093169c8849a9ae9acefb93c3eefc5.tar.gz
+    url: https://github.com/matsubara0507/mix.hs/archive/a0b2b9394c340186c9a8a63808f0db1752ada4ae.tar.gz
     cabal-file:
       size: 1086
       sha256: 4843982f1708e474ad68a9bddc213b5447fb285a71b8c8f720329768056b231b
     name: mix-json-logger
     version: 0.1.0
-    sha256: 8daa72bb527fa53dd5f64eb21f0213a665db671351456468c8dd0da1e129945b
+    sha256: f879d5d044d8531814a8cd5bbda08ab2a513eb04a150e44526ea0f49961e38a1
     pantry-tree:
       size: 334
       sha256: 372be4778ce622e4ed87a5c77b4aa547a12da67c01570f2927f7a82ad9ec509d
   original:
     subdir: mix-json-logger
-    url: https://github.com/matsubara0507/mix.hs/archive/f4cad8e116093169c8849a9ae9acefb93c3eefc5.tar.gz
+    url: https://github.com/matsubara0507/mix.hs/archive/a0b2b9394c340186c9a8a63808f0db1752ada4ae.tar.gz
 - completed:
-    size: 8272
+    size: 8476
     subdir: mix-plugin-github
-    url: https://github.com/matsubara0507/mix.hs/archive/f4cad8e116093169c8849a9ae9acefb93c3eefc5.tar.gz
+    url: https://github.com/matsubara0507/mix.hs/archive/a0b2b9394c340186c9a8a63808f0db1752ada4ae.tar.gz
     cabal-file:
-      size: 1086
-      sha256: 67b254b05a5c5cdee3ca3fb3c35f4acffff0eadb804244774802a958024c0ae2
+      size: 1093
+      sha256: eef0e3f4cdc0f88e532a6b259eb3dfff41d4f9e4821564cb8f2d15f533162a77
     name: mix-plugin-github
-    version: 0.1.2
-    sha256: 8daa72bb527fa53dd5f64eb21f0213a665db671351456468c8dd0da1e129945b
+    version: 0.2.0
+    sha256: f879d5d044d8531814a8cd5bbda08ab2a513eb04a150e44526ea0f49961e38a1
     pantry-tree:
       size: 386
-      sha256: dded091928378429aab079abc4dcdaf81284194a9938a163bd6a389412e11f1f
+      sha256: bf1584e7c1e67bbeb4cb377172f7910c95797d9fb023d372895e0f7727872075
   original:
     subdir: mix-plugin-github
-    url: https://github.com/matsubara0507/mix.hs/archive/f4cad8e116093169c8849a9ae9acefb93c3eefc5.tar.gz
+    url: https://github.com/matsubara0507/mix.hs/archive/a0b2b9394c340186c9a8a63808f0db1752ada4ae.tar.gz
 - completed:
-    size: 8272
+    size: 8476
     subdir: mix-plugin-drone
-    url: https://github.com/matsubara0507/mix.hs/archive/f4cad8e116093169c8849a9ae9acefb93c3eefc5.tar.gz
+    url: https://github.com/matsubara0507/mix.hs/archive/a0b2b9394c340186c9a8a63808f0db1752ada4ae.tar.gz
     cabal-file:
       size: 1098
       sha256: 9d64e3e2d764eb3e9ba3b3fbdf07d9754ec68b0e633384a77d11cfab29985e0d
     name: mix-plugin-drone
     version: 0.2.0
-    sha256: 8daa72bb527fa53dd5f64eb21f0213a665db671351456468c8dd0da1e129945b
+    sha256: f879d5d044d8531814a8cd5bbda08ab2a513eb04a150e44526ea0f49961e38a1
     pantry-tree:
       size: 384
       sha256: 0d1863a2929dd5368e8cfa1481c22c88c76e7633b4114961dfad88879495d912
   original:
     subdir: mix-plugin-drone
-    url: https://github.com/matsubara0507/mix.hs/archive/f4cad8e116093169c8849a9ae9acefb93c3eefc5.tar.gz
+    url: https://github.com/matsubara0507/mix.hs/archive/a0b2b9394c340186c9a8a63808f0db1752ada4ae.tar.gz
 - completed:
-    size: 8272
+    size: 8476
     subdir: mix-plugin-shell
-    url: https://github.com/matsubara0507/mix.hs/archive/f4cad8e116093169c8849a9ae9acefb93c3eefc5.tar.gz
+    url: https://github.com/matsubara0507/mix.hs/archive/a0b2b9394c340186c9a8a63808f0db1752ada4ae.tar.gz
     cabal-file:
       size: 1083
       sha256: ddac0c273cf85cc2629c9bf4cc9a952805e146d601b71324468dcb4ad5aaff95
     name: mix-plugin-shell
     version: 0.1.0
-    sha256: 8daa72bb527fa53dd5f64eb21f0213a665db671351456468c8dd0da1e129945b
+    sha256: f879d5d044d8531814a8cd5bbda08ab2a513eb04a150e44526ea0f49961e38a1
     pantry-tree:
       size: 383
       sha256: 7bbce9d5ea01f6432cecf3151b7c93751d508c0b28444436365eebda58f599d8
   original:
     subdir: mix-plugin-shell
-    url: https://github.com/matsubara0507/mix.hs/archive/f4cad8e116093169c8849a9ae9acefb93c3eefc5.tar.gz
+    url: https://github.com/matsubara0507/mix.hs/archive/a0b2b9394c340186c9a8a63808f0db1752ada4ae.tar.gz
 snapshots:
 - completed:
-    size: 524127
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/6.yaml
-    sha256: dc70dfb45e2c32f54719819bd055f46855dd4b3bd2e58b9f3f38729a2d553fbb
-  original: lts-14.6
+    size: 491372
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/5.yaml
+    sha256: 1b549cfff328040c382a70a84a2087aac8dab6d778bf92f32a93a771a1980dfc
+  original: lts-15.5

--- a/test/GenerateElm.hs
+++ b/test/GenerateElm.hs
@@ -6,7 +6,6 @@ module Main where
 
 import           RIO
 
-import           Data.Proxy              (Proxy (..))
 import           Elm.Mapping
 import           Git.Plantation          (Config, Link, Problem, Repo, Score,
                                           ScoreBoardConfig, Status, Team, User)


### PR DESCRIPTION
- update GHC to 8.8.3
- update extensible to 0.8
    - remove deprecated type and functions
- update drone to 1.1.0 for extensible-0.8
- update github to 0.25
    - change interface from github-0.24
- update mix.hs for extensible-0.8 and github-0.24
- update elmap.hs for new elm-bridge and servant-elm