### PR TITLE
GitHub Container Registry を使う

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,24 +45,34 @@ jobs:
     - name: Build and Test
       run: stack --system-ghc test --local-bin-path=./bin
 
-    - name: Build Docker Image
-      run: docker build -t git-plantation . --build-arg local_bin_path=./bin
-
-    - name: Push Docker Image
-      if: github.ref == 'refs/heads/master'
+    # Build and Push Docker Image
+    - name: Prepare
+      id: prep
       run: |
-        echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u matsubara0507 --password-stdin
-        docker tag git-plantation docker.pkg.github.com/matsubara0507/git-plantation/exe
-        docker push docker.pkg.github.com/matsubara0507/git-plantation/exe:latest
+        DOCKER_IMAGE=ghcr.io/matsubara0507/git-plantation
+        TAGS="${DOCKER_IMAGE}:latest"
+        if [[ $GITHUB_REF == refs/tags/* ]]; then
+          TAGS="$TAGS,${DOCKER_IMAGE}:${GITHUB_REF#refs/tags/}"
+        fi
+        echo ::set-output name=tags::${TAGS}
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Setup Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
 
-    - name: Push Docker Image (tag)
-      if: startsWith(github.ref, 'refs/tags/')
-      run: |
-        echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u matsubara0507 --password-stdin
-        docker tag git-plantation docker.pkg.github.com/matsubara0507/git-plantation/exe:${GITHUB_REF#refs/tags/}
-        docker push docker.pkg.github.com/matsubara0507/git-plantation/exe:${GITHUB_REF#refs/tags/}
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: matsubara0507
+        password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Display .stack size
-      run: |
-        du -sh ~/.stack/*
-        du -sh .stack-work/*
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        builder: ${{ steps.buildx.outputs.name }}
+        tags: ${{ steps.prep.outputs.tags }}
+        push: ${{ github.event_name != 'pull_request' }}
+        build-args: local_bin_path=./bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,49 +13,31 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        ghc: ["8.6.5"]
-        cabal: ["3.0"]
-        cache-version: ["v1"]
+        ghc: ["8.10.4"]
 
     steps:
-    - uses: actions/checkout@v1.1.0
+    - uses: actions/checkout@v2
       with:
         submodules: recursive
-        fetch-depth: 1
 
     - name: Cache .stack
       id: cache-stack
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.stack
-        key: ${{ runner.os }}-stack-${{ hashFiles('**/stack.yaml.lock') }}-${{ matrix.cache-version }}
+        key: "\
+          ${{ runner.os }}-stack\
+          -${{ hashFiles('**/stack.yaml.lock') }}\
+          -${{ hashFiles('**/package.yaml') }}\
+        "
         restore-keys: |
           ${{ runner.os }}-stack-
-
-    - name: Cache .stack/pantry
-      id: cache-pantry
-      uses: actions/cache@v1
-      with:
-        path: ~/.stack-temp/pantry
-        key: ${{ runner.os }}-pantry-${{ hashFiles('**/stack.yaml.lock') }}-${{ matrix.cache-version }}
-        restore-keys: |
-          ${{ runner.os }}-pantry-
-
-    - name: Move .stack/pantry to temp
-      uses: matsubara0507/actions/move-files@master
-      with:
-        source_dir: ~/.stack-temp/pantry
-        source_files: |
-          pantry
-        target_dir: ~/.stack
-
-    - uses: actions/setup-haskell@v1
+    - uses: haskell/actions/setup@v1.2.1
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: ${{ matrix.cabal }}
-
-    - uses: mstksg/setup-stack@v1
+        enable-stack: true
+        stack-version: 'latest'
 
     - name: Install dependencies
       run: stack --system-ghc test --only-dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /work
 COPY . /work
 RUN elm make elm-src/Main.elm --output=static/main.js --optimize
 
-FROM matsubara0507/ubuntu-for-haskell:git
+FROM ghcr.io/matsubara0507/ubuntu-for-haskell:git
 ARG local_bin_path
 WORKDIR /work
 COPY ${local_bin_path} /usr/local/bin

--- a/elm-src/Generated/API.elm
+++ b/elm-src/Generated/API.elm
@@ -1,4 +1,4 @@
-module Generated.API exposing (Config, Link, Problem, Repo, Score, ScoreBoardConfig, Status, Team, User, getApiProblems, getApiScores, getApiScoresByTeam, getApiScoresByTeamByPlayer, getApiTeams, jsonDecConfig, jsonDecLink, jsonDecProblem, jsonDecRepo, jsonDecScore, jsonDecScoreBoardConfig, jsonDecStatus, jsonDecTeam, jsonDecUser, jsonEncConfig, jsonEncLink, jsonEncProblem, jsonEncRepo, jsonEncScore, jsonEncScoreBoardConfig, jsonEncStatus, jsonEncTeam, jsonEncUser)
+module Generated.API exposing (..)
 
 -- The following module comes from bartavelle/json-helpers
 

--- a/src/Git/Plantation/Cmd/Org.hs
+++ b/src/Git/Plantation/Cmd/Org.hs
@@ -56,7 +56,7 @@ createGitHubTeam :: GitHubTeamArg -> Plant ()
 createGitHubTeam args = do
   resp <- MixGitHub.fetch $ GitHub.createTeamForR
     (mkName Proxy $ args ^. #org)
-    (GitHub.CreateTeam (mkName Proxy $ args ^. #gh_team) Nothing mempty GitHub.PermissionPush)
+    (GitHub.CreateTeam (mkName Proxy $ args ^. #gh_team) Nothing mempty GitHub.PrivacyClosed GitHub.PermissionPush)
   case resp of
     Left err -> logDebug (displayShow err) >> throwIO (failure err)
     Right _  -> logInfo $ display success

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,16 +1,17 @@
-resolver: lts-15.5
+resolver: lts-17.9
 packages:
 - .
 extra-deps:
-- extensible-0.8
-- membership-0
-- binary-instances-1.0.0.1
-- servant-github-webhook-0.4.2.0
-- github-webhooks-0.12.0
+- binary-instances-1.0.1
+- extensible-0.8.2
 - drone-1.1.0
 - fallible-0.1.0
+- incremental-0.3.1
+- github-webhooks-0.15.0
+- membership-0
+- servant-github-webhook-0.4.2.0
 - github: matsubara0507/github
-  commit: 8224d498d289c40d3c6d0232ac571a82f8787972
+  commit: 0176698f1cce942c3979f3eb798205e7665e7f55
 - github: matsubara0507/elmap.hs
   commit: 9c9479d3ead6032a0309b5f80f42e94df85da375
   subdirs:
@@ -18,13 +19,14 @@ extra-deps:
   - servant-elmap
   - extensible-elmap
 - github: matsubara0507/mix.hs
-  commit: a0b2b9394c340186c9a8a63808f0db1752ada4ae
+  commit: 75714be080db16f6a4f9d0a22e86947ffcdadc57
   subdirs:
   - mix
   - mix-json-logger
   - mix-plugin-github
   - mix-plugin-drone
   - mix-plugin-shell
+
 docker:
-  repo: matsubara0507/stack-build
+  repo: ghcr.io/matsubara0507/stack-build:18.04
   enable: false

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,40 +5,19 @@
 
 packages:
 - completed:
-    hackage: extensible-0.8@sha256:45ca089909ae434329e4d05dc557be94ff04f24c43ff9b915bd90c0599c83211,2911
-    pantry-tree:
-      size: 2097
-      sha256: d602c9d623afd9186a4d55898ef97f0dfb7f81ffbd5bae86e2238b3694d702fb
-  original:
-    hackage: extensible-0.8
-- completed:
-    hackage: membership-0@sha256:3a11d8fd53cb1a76bb9273e6c929bbf9d649f109714bf487abb3143be04ddc81,995
-    pantry-tree:
-      size: 408
-      sha256: 3b593e0d14e848e318e745555776ebb25210e5e3dec4fde5d3c08ab51ceddc62
-  original:
-    hackage: membership-0
-- completed:
-    hackage: binary-instances-1.0.0.1@sha256:70c5759ab4f09cf661f68b72b3543872bc32b61095159d2bfcda8d71dce29b7e,2637
+    hackage: binary-instances-1.0.1@sha256:974740042381555f9e3614d9fe37136daba155e1f92bc048894698590bcd82f7,2683
     pantry-tree:
       size: 1035
-      sha256: b0d454f73c456c07f02e40002444922ec23278955a222466a8063800aa949c6d
+      sha256: 0a9a584dafcdf5ba0d1fb3586d8061d3002161a5c76ee864025a3878f3139104
   original:
-    hackage: binary-instances-1.0.0.1
+    hackage: binary-instances-1.0.1
 - completed:
-    hackage: servant-github-webhook-0.4.2.0@sha256:fbc981cb5479058ef864c1955190944f7d417d563884560fc3b1911447730ffa,2739
+    hackage: extensible-0.8.2@sha256:f3e7497709199034222e10ba45d3730e21155fb89159ccf1fb0b55f1d7d02697,2963
     pantry-tree:
-      size: 576
-      sha256: 1e27db682388a10c56a58b14b347b5157e6a215164c8102928332e9a62db2b41
+      size: 2041
+      sha256: 29d9d1cfb1c5348141f859e74739d212d3c5af9ff0ec359e3f66f872d4be8bc6
   original:
-    hackage: servant-github-webhook-0.4.2.0
-- completed:
-    hackage: github-webhooks-0.12.0@sha256:38dfaca212c2b75d6a10e270909d42c820f7968cb5937bebc76af0e72c66b058,3911
-    pantry-tree:
-      size: 3448
-      sha256: 6c0fe2f434451ffb8fe4d4652c230cfe57f9c8a647ae66ab420afc7c6de06598
-  original:
-    hackage: github-webhooks-0.12.0
+    hackage: extensible-0.8.2
 - completed:
     hackage: drone-1.1.0@sha256:ec948081678076e905b2a983c7f4d46b60d2ebeae608fe6f7e5c3917dd389d35,2603
     pantry-tree:
@@ -54,26 +33,48 @@ packages:
   original:
     hackage: fallible-0.1.0
 - completed:
-    size: 87815
-    url: https://github.com/matsubara0507/github/archive/8224d498d289c40d3c6d0232ac571a82f8787972.tar.gz
-    cabal-file:
-      size: 7091
-      sha256: dd202179060eb0160e048366a8add67125493a5d54abe53d673175312f4dddf1
-    name: github
-    version: '0.24'
-    sha256: 3dfa0789a1199900203b45901930c21c3646fd78d1e94490dd1444531c06015f
+    hackage: incremental-0.3.1@sha256:9c697bae4f7e5ceb144bde13e03ca2f36b4bc2d0c92bbc02e0a604231ee279c2,1153
     pantry-tree:
-      size: 16236
-      sha256: 266e2e2ecda5e39c95d8d89a52a52dda2bbc87e0986069fcf9577bed7bf72c31
+      size: 370
+      sha256: fd5f40352dbf1602babd2c5db2a120c26e57bbd5ad30b19ce24d04189f6a18d1
   original:
-    url: https://github.com/matsubara0507/github/archive/8224d498d289c40d3c6d0232ac571a82f8787972.tar.gz
+    hackage: incremental-0.3.1
+- completed:
+    hackage: github-webhooks-0.15.0@sha256:4e3459a2c294e033e1959306750c562b9c2a563a77c3a6b0522fc73b221f5387,4064
+    pantry-tree:
+      size: 3677
+      sha256: 4ba1a516ccf329abf184ff801b6af456d5aba045c13de4a171ce85af5084d151
+  original:
+    hackage: github-webhooks-0.15.0
+- completed:
+    hackage: membership-0@sha256:3a11d8fd53cb1a76bb9273e6c929bbf9d649f109714bf487abb3143be04ddc81,995
+    pantry-tree:
+      size: 408
+      sha256: 3b593e0d14e848e318e745555776ebb25210e5e3dec4fde5d3c08ab51ceddc62
+  original:
+    hackage: membership-0
+- completed:
+    hackage: servant-github-webhook-0.4.2.0@sha256:fbc981cb5479058ef864c1955190944f7d417d563884560fc3b1911447730ffa,2739
+    pantry-tree:
+      size: 576
+      sha256: 1e27db682388a10c56a58b14b347b5157e6a215164c8102928332e9a62db2b41
+  original:
+    hackage: servant-github-webhook-0.4.2.0
+- completed:
+    size: 88437
+    url: https://github.com/matsubara0507/github/archive/0176698f1cce942c3979f3eb798205e7665e7f55.tar.gz
+    name: github
+    version: '0.26'
+    sha256: d9f01f29699a3e619549ce1579e9b790b7163ad93f131a4fbd42b37e98e47189
+    pantry-tree:
+      size: 16356
+      sha256: a2220b64bcb183b32b7f2bbdfdce9feca1ff4e2764f9c7dd4cdd0e0b16fb9456
+  original:
+    url: https://github.com/matsubara0507/github/archive/0176698f1cce942c3979f3eb798205e7665e7f55.tar.gz
 - completed:
     size: 19650
     subdir: elmap
     url: https://github.com/matsubara0507/elmap.hs/archive/9c9479d3ead6032a0309b5f80f42e94df85da375.tar.gz
-    cabal-file:
-      size: 1788
-      sha256: e914e320116772e38d19fc5fbbe0db6827fd23f82be6a82c4d1e9691863c5861
     name: elmap
     version: 0.1.0.0
     sha256: 2007d3eaf2df739e27533469921a6bc4ece0fc5d7efdc88ff3afa354a44fbafa
@@ -87,9 +88,6 @@ packages:
     size: 19650
     subdir: servant-elmap
     url: https://github.com/matsubara0507/elmap.hs/archive/9c9479d3ead6032a0309b5f80f42e94df85da375.tar.gz
-    cabal-file:
-      size: 2194
-      sha256: 60205e8a33494474cbc09a5481f83b2cbc4fb41a106a1ed23c74d0eec5661469
     name: servant-elmap
     version: 0.1.0.0
     sha256: 2007d3eaf2df739e27533469921a6bc4ece0fc5d7efdc88ff3afa354a44fbafa
@@ -103,9 +101,6 @@ packages:
     size: 19650
     subdir: extensible-elmap
     url: https://github.com/matsubara0507/elmap.hs/archive/9c9479d3ead6032a0309b5f80f42e94df85da375.tar.gz
-    cabal-file:
-      size: 1744
-      sha256: 2cc0c5e1d41ddede33c6b68e9f7a0ccfacbf10c05c449d551b34bb6df1d3cfd2
     name: extensible-elmap
     version: 0.1.0.0
     sha256: 2007d3eaf2df739e27533469921a6bc4ece0fc5d7efdc88ff3afa354a44fbafa
@@ -116,88 +111,73 @@ packages:
     subdir: extensible-elmap
     url: https://github.com/matsubara0507/elmap.hs/archive/9c9479d3ead6032a0309b5f80f42e94df85da375.tar.gz
 - completed:
-    size: 8476
+    size: 11913
     subdir: mix
-    url: https://github.com/matsubara0507/mix.hs/archive/a0b2b9394c340186c9a8a63808f0db1752ada4ae.tar.gz
-    cabal-file:
-      size: 1110
-      sha256: 946df4a87070784d7ea659f6a3ad2f346f8cf31fea1135fc342feb5a303fa147
+    url: https://github.com/matsubara0507/mix.hs/archive/75714be080db16f6a4f9d0a22e86947ffcdadc57.tar.gz
     name: mix
     version: 0.1.1
-    sha256: f879d5d044d8531814a8cd5bbda08ab2a513eb04a150e44526ea0f49961e38a1
+    sha256: c4aa501c544ab35a214e7b07f2f97fb19de644f48874c8d6838809bcf4d8edb9
     pantry-tree:
       size: 598
       sha256: 689bed307dc233a6c50e01f00295a079dc40a4291700646f3ca423d714ba35fc
   original:
     subdir: mix
-    url: https://github.com/matsubara0507/mix.hs/archive/a0b2b9394c340186c9a8a63808f0db1752ada4ae.tar.gz
+    url: https://github.com/matsubara0507/mix.hs/archive/75714be080db16f6a4f9d0a22e86947ffcdadc57.tar.gz
 - completed:
-    size: 8476
+    size: 11913
     subdir: mix-json-logger
-    url: https://github.com/matsubara0507/mix.hs/archive/a0b2b9394c340186c9a8a63808f0db1752ada4ae.tar.gz
-    cabal-file:
-      size: 1086
-      sha256: 4843982f1708e474ad68a9bddc213b5447fb285a71b8c8f720329768056b231b
+    url: https://github.com/matsubara0507/mix.hs/archive/75714be080db16f6a4f9d0a22e86947ffcdadc57.tar.gz
     name: mix-json-logger
     version: 0.1.0
-    sha256: f879d5d044d8531814a8cd5bbda08ab2a513eb04a150e44526ea0f49961e38a1
+    sha256: c4aa501c544ab35a214e7b07f2f97fb19de644f48874c8d6838809bcf4d8edb9
     pantry-tree:
       size: 334
       sha256: 372be4778ce622e4ed87a5c77b4aa547a12da67c01570f2927f7a82ad9ec509d
   original:
     subdir: mix-json-logger
-    url: https://github.com/matsubara0507/mix.hs/archive/a0b2b9394c340186c9a8a63808f0db1752ada4ae.tar.gz
+    url: https://github.com/matsubara0507/mix.hs/archive/75714be080db16f6a4f9d0a22e86947ffcdadc57.tar.gz
 - completed:
-    size: 8476
+    size: 11913
     subdir: mix-plugin-github
-    url: https://github.com/matsubara0507/mix.hs/archive/a0b2b9394c340186c9a8a63808f0db1752ada4ae.tar.gz
-    cabal-file:
-      size: 1093
-      sha256: eef0e3f4cdc0f88e532a6b259eb3dfff41d4f9e4821564cb8f2d15f533162a77
+    url: https://github.com/matsubara0507/mix.hs/archive/75714be080db16f6a4f9d0a22e86947ffcdadc57.tar.gz
     name: mix-plugin-github
-    version: 0.2.0
-    sha256: f879d5d044d8531814a8cd5bbda08ab2a513eb04a150e44526ea0f49961e38a1
+    version: 0.3.0
+    sha256: c4aa501c544ab35a214e7b07f2f97fb19de644f48874c8d6838809bcf4d8edb9
     pantry-tree:
-      size: 386
-      sha256: bf1584e7c1e67bbeb4cb377172f7910c95797d9fb023d372895e0f7727872075
+      size: 458
+      sha256: 1e6b6c09e62afbd5947ab33f976fb6163a12510477381554d6888adb7e1f39db
   original:
     subdir: mix-plugin-github
-    url: https://github.com/matsubara0507/mix.hs/archive/a0b2b9394c340186c9a8a63808f0db1752ada4ae.tar.gz
+    url: https://github.com/matsubara0507/mix.hs/archive/75714be080db16f6a4f9d0a22e86947ffcdadc57.tar.gz
 - completed:
-    size: 8476
+    size: 11913
     subdir: mix-plugin-drone
-    url: https://github.com/matsubara0507/mix.hs/archive/a0b2b9394c340186c9a8a63808f0db1752ada4ae.tar.gz
-    cabal-file:
-      size: 1098
-      sha256: 9d64e3e2d764eb3e9ba3b3fbdf07d9754ec68b0e633384a77d11cfab29985e0d
+    url: https://github.com/matsubara0507/mix.hs/archive/75714be080db16f6a4f9d0a22e86947ffcdadc57.tar.gz
     name: mix-plugin-drone
     version: 0.2.0
-    sha256: f879d5d044d8531814a8cd5bbda08ab2a513eb04a150e44526ea0f49961e38a1
+    sha256: c4aa501c544ab35a214e7b07f2f97fb19de644f48874c8d6838809bcf4d8edb9
     pantry-tree:
       size: 384
       sha256: 0d1863a2929dd5368e8cfa1481c22c88c76e7633b4114961dfad88879495d912
   original:
     subdir: mix-plugin-drone
-    url: https://github.com/matsubara0507/mix.hs/archive/a0b2b9394c340186c9a8a63808f0db1752ada4ae.tar.gz
+    url: https://github.com/matsubara0507/mix.hs/archive/75714be080db16f6a4f9d0a22e86947ffcdadc57.tar.gz
 - completed:
-    size: 8476
+    size: 11913
     subdir: mix-plugin-shell
-    url: https://github.com/matsubara0507/mix.hs/archive/a0b2b9394c340186c9a8a63808f0db1752ada4ae.tar.gz
-    cabal-file:
-      size: 1083
-      sha256: ddac0c273cf85cc2629c9bf4cc9a952805e146d601b71324468dcb4ad5aaff95
+    url: https://github.com/matsubara0507/mix.hs/archive/75714be080db16f6a4f9d0a22e86947ffcdadc57.tar.gz
     name: mix-plugin-shell
     version: 0.1.0
-    sha256: f879d5d044d8531814a8cd5bbda08ab2a513eb04a150e44526ea0f49961e38a1
+    sha256: c4aa501c544ab35a214e7b07f2f97fb19de644f48874c8d6838809bcf4d8edb9
     pantry-tree:
       size: 383
       sha256: 7bbce9d5ea01f6432cecf3151b7c93751d508c0b28444436365eebda58f599d8
   original:
     subdir: mix-plugin-shell
-    url: https://github.com/matsubara0507/mix.hs/archive/a0b2b9394c340186c9a8a63808f0db1752ada4ae.tar.gz
+    url: https://github.com/matsubara0507/mix.hs/archive/75714be080db16f6a4f9d0a22e86947ffcdadc57.tar.gz
 snapshots:
 - completed:
-    size: 491372
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/5.yaml
-    sha256: 1b549cfff328040c382a70a84a2087aac8dab6d778bf92f32a93a771a1980dfc
-  original: lts-15.5
+    size: 567037
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/9.yaml
+    sha256: d7d8d5106e53d1669964bd8bd2b0f88a5ad192d772f5376384b76738fd992311
+  original: lts-17.9


### PR DESCRIPTION
イメージのプッシュ先を Docker Hub から GHCR に変更します。

ついでに
- LTS の更新（17.9）
    - fork した github package の方もアップストリームに rebase した 
- GitHub Actions のアクションのバージョンアップ
- base image も GHCR のものに変更